### PR TITLE
Remove `.editorconfig`

### DIFF
--- a/examples/.editorconfig
+++ b/examples/.editorconfig
@@ -1,0 +1,3 @@
+[Makefile]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
Presense of this file force me to use TAB to indent JSON files.