### PR TITLE
Remove `div` inside `body`

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -72,7 +72,7 @@ const render = async (
   }";import { HelmetProvider } from "${
     importmap.imports["helmet"]
   }";import App from "/app.js";` +
-    `const root = hydrateRoot(document.getElementById('ultra'),` +
+    `const root = hydrateRoot(document.body,` +
     `createElement(Router, null, createElement(HelmetProvider, null, createElement(App))))` +
     `</script></head><body>`;
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -74,10 +74,10 @@ const render = async (
   }";import App from "/app.js";` +
     `const root = hydrateRoot(document.getElementById('ultra'),` +
     `createElement(Router, null, createElement(HelmetProvider, null, createElement(App))))` +
-    `</script></head><body><div id="ultra">`;
+    `</script></head><body>`;
 
   const tail = () =>
-    `</div></body><script>self.__ultra = ${
+    `</body><script>self.__ultra = ${
       JSON.stringify(Array.from(cache.entries()))
     }</script></html>`;
 


### PR DESCRIPTION
I looked at most of the files in this project and couldn't find any real reason this `div` is included here. Maybe I'm missing something and the `id="ultra"` is actually important,

- if yes, then I'd suggest moving it to the `body` element, like `<body id="ultra">`
- if no, then I'd suggest merging this PR

Main inspiration for this was me being annoyed by this "in-between" element while styling my website through a global css file. It also kind of prevents me to follow HTML best practices, at least I think so. To be fair, after a short research I couldn't find anyone explicitly saying "use elements like `main` and `header` only as direct children of `body`"; it feels weird putting them inside a "generic" `div` though.