### PR TITLE
replace `helmet` with `react-helmet`

### DIFF
--- a/examples/boilerplate/importmap.json
+++ b/examples/boilerplate/importmap.json
@@ -3,7 +3,7 @@
     "react": "https://esm.sh/react@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom/server": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917/server?no-check",
-    "helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "wouter": "https://esm.sh/wouter?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "swr": "https://esm.sh/swr@1.0.0?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "ultra/cache": "https://deno.land/x/ultra@v0.3/cache.js"

--- a/examples/boilerplate/src/app.jsx
+++ b/examples/boilerplate/src/app.jsx
@@ -1,4 +1,4 @@
-import { Helmet } from "helmet";
+import { Helmet } from "react-helmet";
 import React from "react";
 
 const Ultra = () => {

--- a/examples/react18/importmap.json
+++ b/examples/react18/importmap.json
@@ -3,7 +3,7 @@
     "react": "https://esm.sh/react@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom/server": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917/server?no-check",
-    "helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "wouter": "https://esm.sh/wouter?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "swr": "https://esm.sh/swr@1.0.0?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "ultra/cache": "https://deno.land/x/ultra@v0.3/cache.js"

--- a/examples/react18/src/app.jsx
+++ b/examples/react18/src/app.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from "react";
-import { Helmet } from "helmet";
+import { Helmet } from "react-helmet";
 import { Route } from "wouter";
 import { SWRConfig } from "swr";
 import ultraCache from "ultra/cache";

--- a/examples/threejs/importmap.json
+++ b/examples/threejs/importmap.json
@@ -3,7 +3,7 @@
     "react": "https://esm.sh/react@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom/server": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917/server?no-check",
-    "helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "wouter": "https://esm.sh/wouter?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "swr": "https://esm.sh/swr@1.0.0?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "ultra/cache": "https://deno.land/x/ultra@v0.3/cache.js",

--- a/examples/threejs/src/app.jsx
+++ b/examples/threejs/src/app.jsx
@@ -1,4 +1,4 @@
-import { Helmet } from "helmet";
+import { Helmet } from "react-helmet";
 import React, { useEffect, useRef, useState } from "react";
 import { Canvas, useFrame } from "three";
 

--- a/examples/ultra-website/importmap.json
+++ b/examples/ultra-website/importmap.json
@@ -3,7 +3,7 @@
     "react": "https://esm.sh/react@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917?no-check",
     "react-dom/server": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917/server?no-check",
-    "helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "wouter": "https://esm.sh/wouter?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "swr": "https://esm.sh/swr@1.0.0?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle&no-check",
     "ultra/cache": "https://deno.land/x/ultra@v0.3/cache.js"

--- a/examples/ultra-website/src/app.tsx
+++ b/examples/ultra-website/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from "react";
-import { Helmet } from "helmet";
+import { Helmet } from "react-helmet";
 import { Route } from "wouter";
 import { SWRConfig } from "swr";
 import ultraCache from "ultra/cache";

--- a/examples/web3/importmap.json
+++ b/examples/web3/importmap.json
@@ -3,7 +3,7 @@
     "react": "https://esm.sh/react@18.0.0-alpha-bc9bb87c2-20210917",
     "react-dom": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917",
     "react-dom/server": "https://esm.sh/react-dom@18.0.0-alpha-bc9bb87c2-20210917/server",
-    "helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle",
     "wouter": "https://esm.sh/wouter?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle",
     "swr": "https://esm.sh/swr@1.0.0?deps=react@18.0.0-alpha-bc9bb87c2-20210917&bundle",
     "ultra-cache": "https://deno.land/x/ultra@v0.6/cache.js",

--- a/examples/web3/src/app.tsx
+++ b/examples/web3/src/app.tsx
@@ -1,4 +1,4 @@
-import { Helmet } from "helmet";
+import { Helmet } from "react-helmet";
 import React, { useEffect, useState } from "react";
 import { Web3Provider } from "@ethersproject/providers";
 import type { ExternalProvider } from "@ethersproject/providers";

--- a/importmap.json
+++ b/importmap.json
@@ -3,7 +3,7 @@
     "react": "https://esm.sh/react@18.0.0-alpha-67f38366a-20210830",
     "react-dom": "https://esm.sh/react-dom@18.0.0-alpha-67f38366a-20210830",
     "react-dom/server": "https://esm.sh/react-dom@18.0.0-alpha-67f38366a-20210830/server",
-    "helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-67f38366a-20210830&bundle",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18.0.0-alpha-67f38366a-20210830&bundle",
     "wouter": "https://esm.sh/wouter?deps=react@18.0.0-alpha-67f38366a-20210830&bundle",
     "swr": "https://esm.sh/swr@1.0.0?deps=react@18.0.0-alpha-67f38366a-20210830&bundle",
     "ultra-cache": "https://deno.land/x/ultra@v0.3/cache.js",

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import ReactDOM from "react-dom/server";
 import { BaseLocationHook, Router } from "wouter";
-import { HelmetProvider } from "helmet";
+import { HelmetProvider } from "react-helmet";
 import { concat } from "https://deno.land/std@0.107.0/bytes/mod.ts";
 import { join } from "https://deno.land/std@0.107.0/path/mod.ts";
 import { Buffer } from "https://deno.land/std@0.107.0/io/mod.ts";
@@ -70,7 +70,7 @@ const render = async (
   }";import { Router } from "${
     importmap.imports["wouter"]
   }";import { HelmetProvider } from "${
-    importmap.imports["helmet"]
+    importmap.imports["react-helmet"]
   }";import App from "/app.js";` +
     `const root = hydrateRoot(document.body,` +
     `createElement(Router, null, createElement(HelmetProvider, null, createElement(App))))` +


### PR DESCRIPTION
The actual npm module is called "react-helmet". I did this to avoid confusion with the also popular npm module [helmet](https://github.com/helmetjs/helmet) (and because deno crashed on me after I tried to use it :P).

PS: Sorry for all the useless commits before the actual commit, I messed up. This PR should be merged after #28. I can also try to fix it somehow on this branch if it's too much hassle or if #28 takes longer or changes.