### PR TITLE
API Routes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,7 @@ const server = (
     if (url.pathname.startsWith("/api")) {
       type APIHandler = (request: Request) => Response;
       const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
-        const path = `${Deno.cwd()}/src${pathname}.ts`;
+        const path = `${Deno.cwd()}/${dir}${pathname}.ts`;
         const apiHandler: { default: APIHandler } = await import(path);
         return apiHandler.default;
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,13 +74,10 @@ const server = (
       return apiHandler.default;
     };
     if (url.pathname.startsWith("/api")) {
-      let pathname = url.pathname;
-      if (pathname.startsWith("/")) {
-        pathname = pathname.slice(1);
-      }
-      if (pathname.endsWith("/")) {
-        pathname = pathname.slice(0, -1);
-      }
+      let pathname = url.pathname.startsWith("/")
+        ? url.pathname.slice(1)
+        : url.pathname;
+      pathname = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
       try {
         (await importAPIRoute(pathname))(request);
       } catch (_error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -82,11 +82,18 @@ const server = (
         ? url.pathname.slice(0, -1)
         : url.pathname;
       try {
-        return (await importAPIRoute(pathname))(request);
+        console.log("first");
+        const handler = await importAPIRoute(pathname);
+        console.log("first:handler", handler);
+        handler(request);
       } catch (_error) {
         try {
-          return (await importAPIRoute(`${pathname}/index`))(request);
+          console.log("second", _error);
+          const handler = await importAPIRoute(`${pathname}/index`);
+          console.log("second:handler", handler);
+          return handler(request);
         } catch (_error) {
+          console.log("third", _error);
           return new Response(`Not found`, { status: 404 });
         }
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,18 +66,17 @@ const server = (
     };
 
     // API
-    type APIHandler = (request: Request) => Response;
-    const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
-      const apiHandler: { default: APIHandler } = await import(
-        `${Deno.cwd()}/src/${pathname}.ts`
-      );
-      return apiHandler.default;
-    };
     if (url.pathname.startsWith("/api")) {
-      let pathname = url.pathname.startsWith("/")
-        ? url.pathname.slice(1)
+      type APIHandler = (request: Request) => Response;
+      const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
+        const apiHandler: { default: APIHandler } = await import(
+          `${Deno.cwd()}/src${pathname}.ts`
+        );
+        return apiHandler.default;
+      };
+      const pathname = url.pathname.endsWith("/")
+        ? url.pathname.slice(0, -1)
         : url.pathname;
-      pathname = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
       try {
         (await importAPIRoute(pathname))(request);
       } catch (_error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,7 @@ const server = (
     };
 
     // API
+    console.log("cwd", Deno.cwd());
     console.log("Request url.pathname", url.pathname);
     if (url.pathname.startsWith("/api")) {
       console.log("url.pathname starts with /api");

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,19 +69,18 @@ const server = (
     if (url.pathname.startsWith("/api")) {
       type APIHandler = (request: Request) => Response;
       const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
-        const apiHandler: { default: APIHandler } = await import(
-          `${Deno.cwd()}/src${pathname}.ts`
-        );
+        const path = `${Deno.cwd()}/src${pathname}.ts`;
+        const apiHandler: { default: APIHandler } = await import(path);
         return apiHandler.default;
       };
       const pathname = url.pathname.endsWith("/")
         ? url.pathname.slice(0, -1)
         : url.pathname;
       try {
-        (await importAPIRoute(pathname))(request);
+        return (await importAPIRoute(pathname))(request);
       } catch (_error) {
         try {
-          (await importAPIRoute(`${pathname}/index`))(request);
+          return (await importAPIRoute(`${pathname}/index`))(request);
         } catch (_error) {
           return new Response(`Not found`, { status: 404 });
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,35 +66,22 @@ const server = (
     };
 
     // API
-    console.log("cwd", Deno.cwd());
-    console.log("Request url.pathname", url.pathname);
     if (url.pathname.startsWith("/api")) {
-      console.log("url.pathname starts with /api");
       type APIHandler = (request: Request) => Response;
       const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
-        console.log("importAPIRoute", pathname);
         const path = `file://${Deno.cwd()}/${dir}${pathname}.ts`;
-        console.log("importAPIRoute:path", path);
         const apiHandler: { default: APIHandler } = await import(path);
-        console.log("importAPIRoute:apiHandler", apiHandler);
         return apiHandler.default;
       };
       const pathname = url.pathname.endsWith("/")
         ? url.pathname.slice(0, -1)
         : url.pathname;
       try {
-        console.log("first");
-        const handler = await importAPIRoute(pathname);
-        console.log("first:handler", handler);
-        handler(request);
+        return (await importAPIRoute(pathname))(request);
       } catch (_error) {
         try {
-          console.log("second", _error);
-          const handler = await importAPIRoute(`${pathname}/index`);
-          console.log("second:handler", handler);
-          return handler(request);
+          return (await importAPIRoute(`${pathname}/index`))(request);
         } catch (_error) {
-          console.log("third", _error);
           return new Response(`Not found`, { status: 404 });
         }
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,9 +66,12 @@ const server = (
     };
 
     // API
+    console.log("Request url.pathname", url.pathname);
     if (url.pathname.startsWith("/api")) {
+      console.log("url.pathname starts with /api");
       type APIHandler = (request: Request) => Response;
       const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
+        console.log("importAPIRoute", pathname);
         const path = `${Deno.cwd()}/${dir}${pathname}.ts`;
         const apiHandler: { default: APIHandler } = await import(path);
         return apiHandler.default;

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,7 @@ const server = (
       type APIHandler = (request: Request) => Response;
       const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
         console.log("importAPIRoute", pathname);
-        const path = `${Deno.cwd()}/${dir}${pathname}.ts`;
+        const path = `file://${Deno.cwd()}/${dir}${pathname}.ts`;
         console.log("importAPIRoute:path", path);
         const apiHandler: { default: APIHandler } = await import(path);
         console.log("importAPIRoute:apiHandler", apiHandler);

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,9 @@ const server = (
       const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
         console.log("importAPIRoute", pathname);
         const path = `${Deno.cwd()}/${dir}${pathname}.ts`;
+        console.log("importAPIRoute:path", path);
         const apiHandler: { default: APIHandler } = await import(path);
+        console.log("importAPIRoute:apiHandler", apiHandler);
         return apiHandler.default;
       };
       const pathname = url.pathname.endsWith("/")


### PR DESCRIPTION
I would like to have the ability so serve API routes from the lambda / edge that ultra is deployed to. This removes the need to have a separate API deployment.

On line 73 I removed the slash between `"src"` and `pathname` because pathname always starts with a slash.

This PR assumes you want to use the `src/api` directory which might not be in line with the goals/visions of Ultra.

This would solve https://github.com/exhibitionist-digital/ultra/issues/51 .