### PR TITLE
copy static assets

### DIFF
--- a/src/deno/build.ts
+++ b/src/deno/build.ts
@@ -1,7 +1,14 @@
 import assets from "./../assets.ts";
 import transform from "./../transform.ts";
 import { jsify } from "../resolver.ts";
-import { basename, emptyDir, ensureDir, extname } from "./deps.ts";
+import {
+  basename,
+  copy,
+  dirname,
+  emptyDir,
+  ensureDir,
+  extname,
+} from "./deps.ts";
 import vendor from "../vendor.ts";
 import { port } from "../env.ts";
 
@@ -28,16 +35,12 @@ const build = async () => {
   });
   const { raw, transpile } = await assets(sourceDirectory);
 
+  // copy static files
   const rawIterator = raw.keys();
-
   for (let i = 0; i < raw.size; i++) {
     const file = rawIterator.next().value;
-    const source = await Deno.readTextFile(file);
-
-    const directory = file.split("/");
-    const name = directory.pop();
-    await ensureDir(`./.ultra/${directory.join("/")}`);
-    await Deno.writeTextFile(`./.ultra/${directory.join("/")}/${name}`, source);
+    await ensureDir(dirname(`./.ultra/${file}`));
+    await copy(file, `./.ultra/${file}`);
   }
 
   const iterator = transpile.keys();

--- a/src/deno/deps.ts
+++ b/src/deno/deps.ts
@@ -1,9 +1,13 @@
 export { walk } from "https://deno.land/std@0.132.0/fs/mod.ts";
 export { concat } from "https://deno.land/std@0.132.0/bytes/mod.ts";
-export { join } from "https://deno.land/std@0.132.0/path/mod.ts";
+export { dirname, join } from "https://deno.land/std@0.132.0/path/mod.ts";
 export { Buffer } from "https://deno.land/std@0.132.0/io/mod.ts";
 export { serve } from "https://deno.land/std@0.132.0/http/server.ts";
 export { readableStreamFromReader } from "https://deno.land/std@0.132.0/streams/conversion.ts";
 export { basename, extname } from "https://deno.land/std@0.132.0/path/mod.ts";
 export { default as mime } from "https://esm.sh/mime-types@2.1.35";
-export { emptyDir, ensureDir } from "https://deno.land/std@0.132.0/fs/mod.ts";
+export {
+  copy,
+  emptyDir,
+  ensureDir,
+} from "https://deno.land/std@0.132.0/fs/mod.ts";


### PR DESCRIPTION
This fixes a bug with copying static assets on Deno Deploy