### PR TITLE
Removed no-check flag from deno.json tasks

### DIFF
--- a/workspace/deno.json
+++ b/workspace/deno.json
@@ -1,8 +1,8 @@
 {
   "tasks": {
-    "dev": "mode=dev deno run -A --no-check --unstable server.js",
-    "start": "deno run -A --no-check --unstable server.js",
-    "cache": "deno cache --reload --no-check server.js",
+    "dev": "mode=dev deno run -A --unstable server.js",
+    "start": "deno run -A --unstable server.js",
+    "cache": "deno cache --reload server.js",
     "vendor": "importMap=importMap.json deno run -A --unstable ../vendor.ts",
     "e2e": "deno test --unstable -A",
     "build": "deno run -A ../build.ts"


### PR DESCRIPTION
As the React 18 TypeScript types have been [added to Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210), there is no more need for the `--no-check` flag in the `deno.json` tasks.