### PR TITLE
Generic request handler

### DIFF
--- a/src/oak/handler.ts
+++ b/src/oak/handler.ts
@@ -19,9 +19,12 @@ const requestHandler = createRequestHandler({
 });
 
 export async function ultraHandler(context: Context) {
+  const serverRequestBody = context.request.originalRequest.getBody();
+
   const request = new Request(context.request.url.toString(), {
     method: context.request.originalRequest.method,
     headers: context.request.originalRequest.headers,
+    body: serverRequestBody.body,
   });
 
   const response = await requestHandler(request);

--- a/src/oak/handler.ts
+++ b/src/oak/handler.ts
@@ -1,95 +1,46 @@
-import { Context } from "https://deno.land/x/oak@v10.5.1/mod.ts";
-import { extname, LRU, mime, readableStreamFromReader } from "../deps.ts";
-import assets from "../assets.ts";
-import transform from "../transform.ts";
-import render from "../render.ts";
-import { jsxify, tsify, tsxify } from "../resolver.ts";
-import { isDev, lang, root, sourceDirectory, vendorDirectory } from "../env.ts";
+import { Context, NativeRequest } from "https://deno.land/x/oak@v10.5.1/mod.ts";
+import type { ServerRequest } from "https://deno.land/x/oak@v10.5.1/types.d.ts";
+import { isDev, sourceDirectory, vendorDirectory } from "../env.ts";
 import { resolveConfig, resolveImportMap } from "../config.ts";
+import { createRequestHandler } from "../server/requestHandler.ts";
 
-const memory = new LRU(500);
 const cwd = Deno.cwd();
 
 const config = await resolveConfig(cwd);
 const importMap = await resolveImportMap(cwd, config);
-const serverStart = Math.ceil(+new Date() / 100);
+
+/**
+ * @see https://github.com/oakserver/oak/issues/501
+ */
+function isNativeRequest(
+  serverRequest: ServerRequest,
+): serverRequest is NativeRequest {
+  // deno-lint-ignore no-explicit-any
+  return (serverRequest as any).serverRequest instanceof Request;
+}
+
+const requestHandler = createRequestHandler({
+  cwd,
+  importMap,
+  paths: {
+    source: sourceDirectory,
+    vendor: vendorDirectory,
+  },
+  isDev,
+});
 
 export async function ultraHandler(context: Context) {
-  const requestStart = Math.ceil(+new Date() / 100);
-  const cacheBuster = isDev ? requestStart : serverStart;
-  const { raw, transpile } = await assets(sourceDirectory);
-  const x = await assets(`.ultra/${vendorDirectory}`);
-  const requestUrl = context.request.url;
+  const request = isNativeRequest(context.request.originalRequest)
+    ? context.request.originalRequest.request
+    : null;
 
-  // vendor map
-  if (x.raw.has(`.ultra${requestUrl.pathname}`)) {
-    const file = await Deno.open(
-      `./.ultra${requestUrl.pathname}`,
-    );
-    const body = readableStreamFromReader(file);
-    context.response.body = body;
-    return;
+  if (!request) {
+    // Not sure if this will ever be the case?
+    throw new Error("Not a native Request!");
   }
 
-  // static assets
-  if (raw.has(`${sourceDirectory}${requestUrl.pathname}`)) {
-    const file = await Deno.open(
-      `./${sourceDirectory}${requestUrl.pathname}`,
-    );
-    const contentType = mime.lookup(extname(requestUrl.pathname));
-    const body = readableStreamFromReader(file);
-    context.response.type = contentType || "application/octet-stream";
-    context.response.body = body;
-    return;
-  }
+  const response = await requestHandler(request);
 
-  const transpilation = async (file: string) => {
-    let js = memory.get(requestUrl.pathname);
-
-    if (!js) {
-      const source = await Deno.readTextFile(`./${file}`);
-      const t0 = performance.now();
-      js = await transform({
-        source,
-        sourceUrl: requestUrl,
-        importMap,
-        cacheBuster,
-      });
-      const t1 = performance.now();
-      console.log(
-        `Transpile ${file.replace(sourceDirectory, "")} in ${t1 - t0}ms`,
-      );
-      if (!isDev) memory.set(requestUrl.pathname, js);
-    }
-    context.response.type = "text/javascript";
-    // @ts-ignore add js type
-    context.response.body = js;
-    return;
-  };
-
-  // jsx
-  const jsx = `${sourceDirectory}${jsxify(requestUrl.pathname)}`;
-  if (transpile.has(jsx)) {
-    return await transpilation(jsx);
-  }
-
-  // tsx
-  const tsx = `${sourceDirectory}${tsxify(requestUrl.pathname)}`;
-  if (transpile.has(tsx)) {
-    return await transpilation(tsx);
-  }
-
-  // ts
-  const ts = `${sourceDirectory}${tsify(requestUrl.pathname)}`;
-  if (transpile.has(ts)) {
-    return await transpilation(ts);
-  }
-
-  context.response.type = "text/html";
-  context.response.body = await render({
-    url: requestUrl,
-    root,
-    importMap,
-    lang,
-  });
+  context.response.body = response.body;
+  context.response.headers = response.headers;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,198 +1,26 @@
-import { LRU, readableStreamFromReader, serve } from "./deps.ts";
-import assets from "./assets.ts";
-import transform from "./transform.ts";
-import render from "./render.ts";
-import {
-  jsxify,
-  resolveFileUrl,
-  stripTrailingSlash,
-  tsify,
-  tsxify,
-} from "./resolver.ts";
-import {
-  disableStreaming,
-  isDev,
-  lang,
-  port,
-  root,
-  sourceDirectory,
-  vendorDirectory,
-} from "./env.ts";
-import { APIHandler } from "./types.ts";
+import { serve } from "./deps.ts";
+import { isDev, port, root, sourceDirectory, vendorDirectory } from "./env.ts";
 import { resolveConfig, resolveImportMap } from "./config.ts";
+import { createRequestHandler } from "./server/requestHandler.ts";
 
-const memory = new LRU(500);
 const cwd = Deno.cwd();
-
 const config = await resolveConfig(cwd);
 const importMap = await resolveImportMap(cwd, config);
 
 const server = () => {
-  const serverStart = Math.ceil(+new Date() / 100);
-  const listeners = new Set<WebSocket>();
-
-  const handler = async (request: Request) => {
-    const requestStart = Math.ceil(+new Date() / 100);
-    const cacheBuster = isDev ? requestStart : serverStart;
-    const { raw, transpile } = await assets(sourceDirectory);
-    const vendor = await assets(`.ultra/${vendorDirectory}`);
-    const requestUrl = new URL(request.url);
-
-    // web socket listener
-    if (isDev) {
-      if (requestUrl.pathname == "/_ultra_socket") {
-        const { socket, response } = Deno.upgradeWebSocket(request);
-        listeners.add(socket);
-        socket.onclose = () => {
-          listeners.delete(socket);
-        };
-        return response;
-      }
-    }
-
-    // vendor map
-    if (vendor.raw.has(".ultra" + requestUrl.pathname)) {
-      const headers = {
-        "content-type": "text/javascript",
-      };
-
-      const file = await Deno.open(
-        `./.ultra${requestUrl.pathname}`,
-      );
-      const body = readableStreamFromReader(file);
-
-      return new Response(body, { headers });
-    }
-
-    // static assets
-    if (raw.has(`${sourceDirectory}${requestUrl.pathname}`)) {
-      const contentType = raw.get(`${sourceDirectory}${requestUrl.pathname}`);
-      const headers = {
-        "content-type": contentType,
-      };
-
-      const file = await Deno.open(
-        `./${sourceDirectory}${requestUrl.pathname}`,
-      );
-      const body = readableStreamFromReader(file);
-
-      return new Response(body, { headers });
-    }
-
-    const transpilation = async (file: string) => {
-      const headers = {
-        "content-type": "text/javascript",
-      };
-
-      let js = memory.get(requestUrl.pathname);
-
-      if (!js) {
-        const source = await Deno.readTextFile(resolveFileUrl(cwd, file));
-        const t0 = performance.now();
-
-        js = await transform({
-          source,
-          sourceUrl: requestUrl,
-          importMap,
-          cacheBuster,
-        });
-
-        const t1 = performance.now();
-        const duration = (t1 - t0).toFixed(2);
-
-        console.log(`Transpile ${file} in ${duration}ms`);
-
-        if (!isDev) memory.set(requestUrl.pathname, js);
-      }
-
-      //@ts-ignore any
-      return new Response(js, { headers });
-    };
-
-    // API
-    if (requestUrl.pathname.startsWith("/api")) {
-      const apiPaths = new Map([...raw, ...transpile]);
-      const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
-        let path = `${sourceDirectory}${pathname}`;
-        if (apiPaths.has(`${path}.js`)) {
-          path = `file://${cwd}/${path}.js`;
-        } else if (apiPaths.has(`${path}.ts`)) {
-          path = `file://${cwd}/${path}.ts`;
-        } else if (apiPaths.has(`${path}/index.js`)) {
-          path = `file://${cwd}/${path}/index.js`;
-        } else if (apiPaths.has(`${path}/index.ts`)) {
-          path = `file://${cwd}/${path}/index.ts`;
-        }
-        return (await import(`${path}?ts=${cacheBuster}`)).default;
-      };
-      try {
-        const pathname = stripTrailingSlash(requestUrl.pathname);
-        const handler = await importAPIRoute(pathname);
-        const response = await handler(request);
-        return response;
-      } catch (error) {
-        console.error(error);
-        return new Response("Internal Server Error", {
-          status: 500,
-          headers: {
-            "content-type": "text/html; charset=utf-8",
-          },
-        });
-      }
-    }
-
-    // jsx
-    const jsx = `${sourceDirectory}${jsxify(requestUrl.pathname)}`;
-    if (transpile.has(jsx)) {
-      return await transpilation(jsx);
-    }
-
-    // tsx
-    const tsx = `${sourceDirectory}${tsxify(requestUrl.pathname)}`;
-    if (transpile.has(tsx)) {
-      return await transpilation(tsx);
-    }
-
-    // ts
-    const ts = `${sourceDirectory}${tsify(requestUrl.pathname)}`;
-    if (transpile.has(ts)) {
-      return await transpilation(ts);
-    }
-
-    return new Response(
-      await render({
-        url: requestUrl,
-        root,
-        importMap,
-        lang,
-        disableStreaming: !!disableStreaming,
-      }),
-      {
-        headers: {
-          "content-type": "text/html; charset=utf-8",
-        },
-      },
-    );
-  };
-
-  // async file watcher to send socket messages
-  if (isDev) {
-    (async () => {
-      for await (
-        const { kind } of Deno.watchFs(sourceDirectory, { recursive: true })
-      ) {
-        if (kind === "modify" || kind === "create") {
-          for (const socket of listeners) {
-            socket.send("reload");
-          }
-        }
-      }
-    })();
-  }
+  const requestHandler = createRequestHandler({
+    cwd,
+    importMap,
+    paths: {
+      source: sourceDirectory,
+      vendor: vendorDirectory,
+    },
+    isDev,
+  });
 
   console.log(`Ultra running ${root}`);
 
-  return serve(handler, { port: +port });
+  return serve(requestHandler, { port: +port });
 };
 
 export default server;

--- a/src/server/requestHandler.ts
+++ b/src/server/requestHandler.ts
@@ -1,0 +1,195 @@
+import assets from "../assets.ts";
+import { LRU, readableStreamFromReader } from "../deps.ts";
+import { disableStreaming, lang, root } from "../env.ts";
+import render from "../render.ts";
+import {
+  jsxify,
+  resolveFileUrl,
+  stripTrailingSlash,
+  tsify,
+  tsxify,
+} from "../resolver.ts";
+import transform from "../transform.ts";
+import type { APIHandler, ImportMap } from "../types.ts";
+
+type CreateRequestHandlerOptions = {
+  cwd: string;
+  importMap: ImportMap;
+  paths: {
+    source: string;
+    vendor: string;
+  };
+  isDev?: boolean;
+};
+
+export function createRequestHandler(options: CreateRequestHandlerOptions) {
+  const {
+    cwd,
+    importMap,
+    paths: { source: sourceDirectory, vendor: vendorDirectory },
+    isDev,
+  } = options;
+
+  const memory = new LRU(500);
+  const serverStart = Math.ceil(+new Date() / 100);
+  const listeners = new Set<WebSocket>();
+
+  // async file watcher to send socket messages
+  if (isDev) {
+    (async () => {
+      for await (
+        const { kind } of Deno.watchFs(sourceDirectory, { recursive: true })
+      ) {
+        if (kind === "modify" || kind === "create") {
+          for (const socket of listeners) {
+            socket.send("reload");
+          }
+        }
+      }
+    })();
+  }
+
+  return async function requestHandler(request: Request): Promise<Response> {
+    const requestStart = Math.ceil(+new Date() / 100);
+    const cacheBuster = isDev ? requestStart : serverStart;
+    const { raw, transpile } = await assets(sourceDirectory);
+    const vendor = await assets(`.ultra/${vendorDirectory}`);
+    const requestUrl = new URL(request.url);
+
+    // web socket listener
+    if (isDev) {
+      if (requestUrl.pathname == "/_ultra_socket") {
+        const { socket, response } = Deno.upgradeWebSocket(request);
+        listeners.add(socket);
+        socket.onclose = () => {
+          listeners.delete(socket);
+        };
+        return response;
+      }
+    }
+
+    // vendor map
+    if (vendor.raw.has(".ultra" + requestUrl.pathname)) {
+      const headers = {
+        "content-type": "text/javascript",
+      };
+
+      const file = await Deno.open(
+        `./.ultra${requestUrl.pathname}`,
+      );
+      const body = readableStreamFromReader(file);
+
+      return new Response(body, { headers });
+    }
+
+    // static assets
+    if (raw.has(`${sourceDirectory}${requestUrl.pathname}`)) {
+      const contentType = raw.get(`${sourceDirectory}${requestUrl.pathname}`);
+      const headers = {
+        "content-type": contentType,
+      };
+
+      const file = await Deno.open(
+        `./${sourceDirectory}${requestUrl.pathname}`,
+      );
+      const body = readableStreamFromReader(file);
+
+      return new Response(body, { headers });
+    }
+
+    const transpilation = async (file: string) => {
+      const headers = {
+        "content-type": "text/javascript",
+      };
+
+      let js = memory.get(requestUrl.pathname);
+
+      if (!js) {
+        const source = await Deno.readTextFile(resolveFileUrl(cwd, file));
+        const t0 = performance.now();
+
+        js = await transform({
+          source,
+          sourceUrl: requestUrl,
+          importMap,
+          cacheBuster,
+        });
+
+        const t1 = performance.now();
+        const duration = (t1 - t0).toFixed(2);
+
+        console.log(`Transpile ${file} in ${duration}ms`);
+
+        if (!isDev) memory.set(requestUrl.pathname, js);
+      }
+
+      //@ts-ignore any
+      return new Response(js, { headers });
+    };
+
+    // API
+    if (requestUrl.pathname.startsWith("/api")) {
+      const apiPaths = new Map([...raw, ...transpile]);
+      const importAPIRoute = async (pathname: string): Promise<APIHandler> => {
+        let path = `${sourceDirectory}${pathname}`;
+        if (apiPaths.has(`${path}.js`)) {
+          path = `file://${cwd}/${path}.js`;
+        } else if (apiPaths.has(`${path}.ts`)) {
+          path = `file://${cwd}/${path}.ts`;
+        } else if (apiPaths.has(`${path}/index.js`)) {
+          path = `file://${cwd}/${path}/index.js`;
+        } else if (apiPaths.has(`${path}/index.ts`)) {
+          path = `file://${cwd}/${path}/index.ts`;
+        }
+        return (await import(`${path}?ts=${cacheBuster}`)).default;
+      };
+      try {
+        const pathname = stripTrailingSlash(requestUrl.pathname);
+        const handler = await importAPIRoute(pathname);
+        const response = await handler(request);
+        return response;
+      } catch (error) {
+        console.error(error);
+        return new Response("Internal Server Error", {
+          status: 500,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        });
+      }
+    }
+
+    // jsx
+    const jsx = `${sourceDirectory}${jsxify(requestUrl.pathname)}`;
+    if (transpile.has(jsx)) {
+      return await transpilation(jsx);
+    }
+
+    // tsx
+    const tsx = `${sourceDirectory}${tsxify(requestUrl.pathname)}`;
+    if (transpile.has(tsx)) {
+      return await transpilation(tsx);
+    }
+
+    // ts
+    const ts = `${sourceDirectory}${tsify(requestUrl.pathname)}`;
+    if (transpile.has(ts)) {
+      return await transpilation(ts);
+    }
+
+    return new Response(
+      await render({
+        url: requestUrl,
+        root,
+        importMap,
+        lang,
+        disableStreaming: !!disableStreaming,
+      }),
+      {
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+        },
+      },
+    );
+  };
+}

--- a/workspace/deno.json
+++ b/workspace/deno.json
@@ -3,6 +3,7 @@
     "dev": "mode=dev deno run -A --unstable --no-check server.js",
     "dev:oak": "mode=dev deno run -A --unstable --no-check oak.ts",
     "start": "deno run -A --unstable --no-check server.js",
+    "start:oak": "deno run -A --unstable --no-check oak.ts",
     "cache": "deno cache --reload server.js",
     "vendor": "importMap=importMap.json deno run -A --unstable ../vendor.ts",
     "build": "deno run -A ../build.ts"

--- a/workspace/deno.json
+++ b/workspace/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
     "dev": "mode=dev deno run -A --unstable --no-check server.js",
+    "dev:oak": "mode=dev deno run -A --unstable --no-check oak.ts",
     "start": "deno run -A --unstable --no-check server.js",
     "cache": "deno cache --reload server.js",
     "vendor": "importMap=importMap.json deno run -A --unstable ../vendor.ts",

--- a/workspace/oak.ts
+++ b/workspace/oak.ts
@@ -19,5 +19,5 @@ app.use(router.allowedMethods());
 // other route matches
 app.use(ultraHandler);
 
-console.log(`Ultra + Oak listening on http://localhost:${port}`);
+console.log(`Ultra running on http://localhost:${port}`);
 await app.listen({ port });

--- a/workspace/tests/helpers.ts
+++ b/workspace/tests/helpers.ts
@@ -2,9 +2,9 @@ import puppeteer from "https://deno.land/x/puppeteer@9.0.2/mod.ts";
 import { join } from "https://deno.land/std@0.135.0/path/mod.ts";
 import { readLines } from "https://deno.land/std@0.135.0/io/mod.ts";
 
-export async function startTestServer() {
+export async function startTestServer(taskName = "start") {
   const serverProcess = Deno.run({
-    cmd: ["deno", "task", "start"],
+    cmd: ["deno", "task", taskName],
     cwd: join(Deno.cwd(), "./workspace"),
     stdout: "piped",
     stderr: "piped",

--- a/workspace/tests/workspace_home.test.ts
+++ b/workspace/tests/workspace_home.test.ts
@@ -2,21 +2,37 @@ import {
   assertEquals,
   fail,
 } from "https://deno.land/std@0.135.0/testing/asserts.ts";
+import { Page } from "https://deno.land/x/puppeteer@9.0.2/mod.ts";
 import { launchLocalhostBrowser, startTestServer } from "./helpers.ts";
 
-Deno.test("puppeteer", async (t) => {
+const expectations = [
+  { text: "Ultra", selector: "h1" },
+  { text: "un-bundle the web", selector: "h2" },
+  { text: "This is a lazily loaded component", selector: "h3" },
+];
+
+async function assertExpectedPageElements(page: Page) {
+  for (const expected of expectations) {
+    const selection = await page.waitForSelector(expected.selector);
+    if (selection) {
+      const text = await page.evaluate(
+        (element) => element.textContent,
+        selection,
+      );
+      assertEquals(text, expected.text);
+    } else {
+      fail(`ERROR: Selector ${expected.selector} not found`);
+    }
+  }
+}
+
+Deno.test("puppeteer: native server", async (t) => {
   const server = await startTestServer();
   const browser = await launchLocalhostBrowser();
 
   await t.step(
     "Should render home page of workspace example app with expected text",
     async () => {
-      const expectations = [
-        { text: "Ultra", selector: "h1" },
-        { text: "un-bundle the web", selector: "h2" },
-        { text: "This is a lazily loaded component", selector: "h3" },
-      ];
-
       try {
         const page = await browser.newPage();
         await page.setViewport({ width: 979, height: 865 });
@@ -24,18 +40,32 @@ Deno.test("puppeteer", async (t) => {
           waitUntil: "networkidle0",
         });
 
-        for (const expected of expectations) {
-          const selection = await page.waitForSelector(expected.selector);
-          if (selection) {
-            const text = await page.evaluate(
-              (element) => element.textContent,
-              selection,
-            );
-            assertEquals(text, expected.text);
-          } else {
-            fail(`ERROR: Selector ${expected.selector} not found`);
-          }
-        }
+        await assertExpectedPageElements(page);
+      } catch (error) {
+        throw error;
+      }
+    },
+  );
+
+  await browser.close();
+  server?.close();
+});
+
+Deno.test("puppeteer: oak server", async (t) => {
+  const server = await startTestServer("start:oak");
+  const browser = await launchLocalhostBrowser();
+
+  await t.step(
+    "Should render home page of workspace example app with expected text",
+    async () => {
+      try {
+        const page = await browser.newPage();
+        await page.setViewport({ width: 979, height: 865 });
+        await page.goto("http://localhost:8000/", {
+          waitUntil: "networkidle0",
+        });
+
+        await assertExpectedPageElements(page);
       } catch (error) {
         throw error;
       }


### PR DESCRIPTION
This PR moves a lot of duplicated code between the Deno native and Oak server implementations to a factory function

```ts
createRequestHandler(options: CreateRequestHandlerOptions) => ((request: Request) => Promise<Response>)
```