### PR TITLE
fix: type conflicts

### DIFF
--- a/workspace/deno.json
+++ b/workspace/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
-    "dev": "mode=dev deno run -A --unstable --no-check server.js",
-    "start": "deno run -A --unstable --no-check server.js",
+    "dev": "mode=dev deno run -A --unstable server.js",
+    "start": "deno run -A --unstable server.js",
     "cache": "deno cache --reload server.js",
     "vendor": "importMap=importMap.json deno run -A --unstable ../vendor.ts",
     "build": "deno run -A ../build.ts"

--- a/workspace/importMap.json
+++ b/workspace/importMap.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "react": "https://esm.sh/react@18",
+    "react": "https://esm.sh/react@18?deps=@types/react@18.0.1",
     "react-dom": "https://esm.sh/react-dom@18",
     "react-dom/server": "https://esm.sh/react-dom@18/server",
     "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18",


### PR DESCRIPTION
This PR fixes type conflicts in the `workspace`

`https://esm.sh/react@18` would resolve react types to `@types/react@18.0.0`

Whereas 

`https://esm.sh/react-dom@18/server`  would resolve react types to `@types/react@18.0.1`

So we just override the types dependency for react