### PR TITLE
Add JSDoc comment for 'Cache' type

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {Map} Cache
+ * @param {Cache} cache
+ * @returns {Cache}
+ */
 const ultraCache = (cache) => {
   if (self.__ultra instanceof Array) return new Map(self.__ultra);
   else if (cache instanceof Map) return cache;

--- a/cache.js
+++ b/cache.js
@@ -1,12 +1,15 @@
+// @ts-check
+
 /**
- * @typedef {Map} Cache
+ * @typedef {Map<unknown, unknown>} Cache
  * @param {Cache} cache
  * @returns {Cache}
  */
 const ultraCache = (cache) => {
-  if (self.__ultra instanceof Array) return new Map(self.__ultra);
-  else if (cache instanceof Map) return cache;
-  else return new Map();
+  const __ultra = self?.__ultra || new Map();
+  if (__ultra instanceof Array) return new Map(__ultra);
+  if (cache instanceof Map) return cache;
+  return new Map();
 };
 
 export default ultraCache;


### PR DESCRIPTION
This PR reflects the minimum scaffolding to fix #77.

Prior to this commit, the docs outline separately importing the 'cache' type from './src/types.ts' which requires statically defining the import rather than adding it to 'importMap.json'. @mashaal suggested using JSDoc to make the 'Cache' type known on import of 'cache.js' which eliminates the need to separately import it.

Rather than use the JSDoc import syntax, `Map` is [universally supported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#browser_compatibility) so I opted to simply `@typedef` to avoid edge cases I'm not familiar with. It's been quite some time since I've dabbled with JS/TS/Deno, so please let me know if any changes are needed. Thank you!