### PR TITLE
Introduce unstable entrypoint and workspace

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
   },
   "lint": {
     "files": {
-      "exclude": ["workspace/.ultra/"]
+      "exclude": ["workspace/.ultra/", "src/unstable/"]
     }
   },
   "fmt": {

--- a/src/unstable/README.md
+++ b/src/unstable/README.md
@@ -1,0 +1,4 @@
+# unstable
+
+This is the home for unstable/experimental features, use at your own risk, as
+things will break.

--- a/src/unstable/deps.ts
+++ b/src/unstable/deps.ts
@@ -1,0 +1,6 @@
+export { default as outdent } from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+export {
+  bold,
+  underline,
+  yellow,
+} from "https://deno.land/std@0.136.0/fmt/colors.ts";

--- a/src/unstable/server.ts
+++ b/src/unstable/server.ts
@@ -1,0 +1,29 @@
+import type { FunctionComponent } from "react";
+import { isDev, port, root, sourceDirectory, vendorDirectory } from "../env.ts";
+import { resolveConfig, resolveImportMap } from "../config.ts";
+import { serve } from "../deps.ts";
+import { createRequestHandler } from "../server/requestHandler.ts";
+import type { RequestContext, ServerOptions } from "./types.ts";
+
+const cwd = Deno.cwd();
+const config = await resolveConfig(cwd);
+const importMap = await resolveImportMap(cwd, config);
+
+export function unstable_ultra(
+  App: FunctionComponent<{ requestContext: RequestContext }>,
+  options?: ServerOptions,
+): Promise<void> {
+  const requestHandler = createRequestHandler({
+    cwd,
+    importMap,
+    paths: {
+      source: sourceDirectory,
+      vendor: vendorDirectory,
+    },
+    isDev,
+  });
+
+  console.log(`Ultra running ${root}`);
+
+  return serve(requestHandler, { port: +port });
+}

--- a/src/unstable/types.ts
+++ b/src/unstable/types.ts
@@ -1,0 +1,19 @@
+import type { FunctionComponent } from "react";
+
+export type RequestContext = {
+  url: URL;
+};
+
+// deno-lint-ignore ban-types
+export type AppProps<P = {}> = P & {
+  requestContext: RequestContext;
+};
+
+export type AppComponent = FunctionComponent<AppProps>;
+
+export type ServerOptions = {
+  createRequestContext?:
+    ((request: Request) => Promise<RequestContext> | RequestContext);
+};
+
+export type RenderOptions = {};

--- a/unstable.ts
+++ b/unstable.ts
@@ -8,7 +8,7 @@ console.warn(
     bold(outdent`Hey now! Looks like you're using unstable Ultra features.
     File any issues you encounter at ${
       underline(
-        "https://github.com/exhibitionist-digital/ultra/issues/new?labels=unstable,bug",
+        "https://github.com/exhibitionist-digital/ultra/issues/new?labels=unstable",
       )
     }`),
   ),

--- a/unstable.ts
+++ b/unstable.ts
@@ -1,0 +1,15 @@
+import { bold, outdent, underline, yellow } from "./src/unstable/deps.ts";
+
+export { unstable_ultra } from "./src/unstable/server.ts";
+export * from "./src/unstable/types.ts";
+
+console.warn(
+  yellow(
+    bold(outdent`Hey now! Looks like you're using unstable Ultra features.
+    File any issues you encounter at ${
+      underline(
+        "https://github.com/exhibitionist-digital/ultra/issues/new?labels=unstable,bug",
+      )
+    }`),
+  ),
+);

--- a/workspace_unstable/deno.json
+++ b/workspace_unstable/deno.json
@@ -1,0 +1,20 @@
+{
+  "tasks": {
+    "dev": "mode=dev deno run -A --unstable --no-check server.ts",
+    "start": "deno run -A --unstable --no-check server.ts",
+    "cache": "deno cache --reload server.ts",
+    "vendor": "importMap=importMap.json deno run -A --unstable ../vendor.ts",
+    "build": "deno run -A ../build.ts"
+  },
+  "importMap": "./importMap.json",
+  "lint": {
+    "files": {
+      "exclude": [".ultra/"]
+    }
+  },
+  "fmt": {
+    "files": {
+      "exclude": [".ultra/"]
+    }
+  }
+}

--- a/workspace_unstable/importMap.json
+++ b/workspace_unstable/importMap.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "react": "https://esm.sh/react@18?dev",
+    "react-dom": "https://esm.sh/react-dom@18?dev",
+    "react-dom/client": "https://esm.sh/react-dom@18/client?dev",
+    "react-dom/server": "https://esm.sh/react-dom@18/server?dev",
+    "react-helmet": "https://esm.sh/react-helmet-async?deps=react@18"
+  }
+}

--- a/workspace_unstable/server.ts
+++ b/workspace_unstable/server.ts
@@ -1,0 +1,4 @@
+import { unstable_ultra } from "../unstable.ts";
+import App from "./src/app.tsx";
+
+await unstable_ultra(App);

--- a/workspace_unstable/src/app.tsx
+++ b/workspace_unstable/src/app.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import type { AppProps } from "../../unstable.ts";
+
+export default function App({ requestContext }: AppProps) {
+  return (
+    <div>
+      Hello World!
+      <pre>{JSON.stringify(requestContext, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces an entrypoint `unstable.ts` and a `workspace_unstable` which will export any experimental features, from `src/unstable`

This shouldn't affect any other PR's as it's all new code.