### PR TITLE
Resolver refactor

### DIFF
--- a/src/deno/build.ts
+++ b/src/deno/build.ts
@@ -1,6 +1,6 @@
 import assets from "./../assets.ts";
 import transform from "./../transform.ts";
-import { jsify } from "../resolver.ts";
+import { replaceFileExt } from "../resolver.ts";
 import {
   basename,
   copy,
@@ -29,7 +29,7 @@ const build = async () => {
   Object.keys(vendorMap.imports)?.forEach((k) => {
     const im: string = vendorMap.imports[k];
     if (im.indexOf("http") < 0) {
-      vendorMap.imports[k] = jsify(im);
+      vendorMap.imports[k] = replaceFileExt(im, ".js");
     }
   });
   const { raw, transpile } = await assets(sourceDirectory);

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,8 +1,14 @@
-export { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
+export {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.135.0/testing/asserts.ts";
 export { walk } from "https://deno.land/std@0.135.0/fs/mod.ts";
 export { concat } from "https://deno.land/std@0.135.0/bytes/mod.ts";
 export {
+  extname,
+  format,
   join,
+  parse,
   relative,
   resolve,
   toFileUrl,
@@ -12,7 +18,6 @@ export { serve } from "https://deno.land/std@0.135.0/http/server.ts";
 export { readableStreamFromReader } from "https://deno.land/std@0.135.0/streams/conversion.ts";
 export { createCache } from "https://deno.land/x/deno_cache@0.2.1/mod.ts";
 export { createGraph } from "https://deno.land/x/deno_graph@0.25.0/mod.ts";
-export { extname } from "https://deno.land/std@0.135.0/path/mod.ts";
 export { default as mime } from "https://esm.sh/mime-types@2.1.35";
 export { default as LRU } from "https://deno.land/x/lru@1.0.2/mod.ts";
 export type {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,23 +1,23 @@
 import { crypto, extname, resolve, toFileUrl } from "./deps.ts";
 import { apiDirectory } from "./env.ts";
 
-export const jsify = (file: string) => {
+export const jsify = (file: string): string => {
   return file.replace(extname(file), ".js");
 };
 
-export const tsify = (file: string) => {
+export const tsify = (file: string): string => {
   return file.replace(extname(file), ".ts");
 };
 
-export const jsxify = (file: string) => {
+export const jsxify = (file: string): string => {
   return file.replace(extname(file), ".jsx");
 };
 
-export const tsxify = (file: string) => {
+export const tsxify = (file: string): string => {
   return file.replace(extname(file), ".tsx");
 };
 
-export const isValidUrl = (url: string) => {
+export const isValidUrl = (url: string): URL | false => {
   try {
     return new URL(url);
   } catch (_e) {
@@ -25,7 +25,7 @@ export const isValidUrl = (url: string) => {
   }
 };
 
-export const hashFile = (url: string) => {
+export const hashFile = (url: string): string => {
   // strip query params from hashing
   url = url.split("?")[0];
   const msgUint8 = new TextEncoder().encode(url);
@@ -37,7 +37,7 @@ export const hashFile = (url: string) => {
   return hashHex;
 };
 
-export const stripTrailingSlash = (url: string) => {
+export const stripTrailingSlash = (url: string): string => {
   return url.endsWith("/") ? url.slice(0, -1) : url;
 };
 
@@ -45,7 +45,7 @@ export const resolveFileUrl = (from: string, to: string) => {
   return new URL(toFileUrl(resolve(from, to)).toString());
 };
 
-export const cacheBuster = (source: string, timestamp?: number) => {
+export const cacheBuster = (source: string, timestamp?: number): string => {
   return source.replace(
     /\.(j|t)sx?/gi,
     () => {
@@ -54,15 +54,15 @@ export const cacheBuster = (source: string, timestamp?: number) => {
   );
 };
 
-export const isRemoteSource = (value: string) => {
+export const isRemoteSource = (value: string): boolean => {
   return value.startsWith("https://") ||
     value.startsWith("http://");
 };
 
-export const isVendorSource = (value: string, vendorDirectory: string) => {
+export const isVendorSource = (value: string, vendorDirectory: string): boolean => {
   return value.indexOf(`.ultra/${vendorDirectory}`) >= 0;
 };
 
-export const isApiRoute = (value: string) => {
+export const isApiRoute = (value: string): boolean => {
   return value.indexOf(apiDirectory) >= 0;
 };

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,20 +1,13 @@
-import { crypto, extname, resolve, toFileUrl } from "./deps.ts";
+import { crypto, format, parse, resolve, toFileUrl } from "./deps.ts";
 import { apiDirectory } from "./env.ts";
 
-export const jsify = (file: string): string => {
-  return file.replace(extname(file), ".js");
-};
+export type ValidExtensions = ".js" | ".jsx" | ".ts" | ".tsx";
 
-export const tsify = (file: string): string => {
-  return file.replace(extname(file), ".ts");
-};
-
-export const jsxify = (file: string): string => {
-  return file.replace(extname(file), ".jsx");
-};
-
-export const tsxify = (file: string): string => {
-  return file.replace(extname(file), ".tsx");
+export const replaceFileExt = (
+  file: string,
+  extension: ValidExtensions,
+): string => {
+  return format({ ...parse(file), base: "", ext: extension });
 };
 
 export const isValidUrl = (url: string): URL | false => {
@@ -59,10 +52,13 @@ export const isRemoteSource = (value: string): boolean => {
     value.startsWith("http://");
 };
 
-export const isVendorSource = (value: string, vendorDirectory: string): boolean => {
-  return value.indexOf(`.ultra/${vendorDirectory}`) >= 0;
+export const isVendorSource = (
+  value: string,
+  vendorDirectory: string,
+): boolean => {
+  return value.includes(`.ultra/${vendorDirectory}`);
 };
 
 export const isApiRoute = (value: string): boolean => {
-  return value.indexOf(apiDirectory) >= 0;
+  return value.includes(apiDirectory);
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,11 +3,9 @@ import assets from "./assets.ts";
 import transform from "./transform.ts";
 import render from "./render.ts";
 import {
-  jsxify,
+  replaceFileExt,
   resolveFileUrl,
   stripTrailingSlash,
-  tsify,
-  tsxify,
 } from "./resolver.ts";
 import {
   disableStreaming,
@@ -142,19 +140,25 @@ const server = () => {
     }
 
     // jsx
-    const jsx = `${sourceDirectory}${jsxify(requestUrl.pathname)}`;
+    const jsx = `${sourceDirectory}${
+      replaceFileExt(requestUrl.pathname, ".jsx")
+    }`;
     if (transpile.has(jsx)) {
       return await transpilation(jsx);
     }
 
     // tsx
-    const tsx = `${sourceDirectory}${tsxify(requestUrl.pathname)}`;
+    const tsx = `${sourceDirectory}${
+      replaceFileExt(requestUrl.pathname, ".tsx")
+    }`;
     if (transpile.has(tsx)) {
       return await transpilation(tsx);
     }
 
     // ts
-    const ts = `${sourceDirectory}${tsify(requestUrl.pathname)}`;
+    const ts = `${sourceDirectory}${
+      replaceFileExt(requestUrl.pathname, ".ts")
+    }`;
     if (transpile.has(ts)) {
       return await transpilation(ts);
     }


### PR DESCRIPTION
All the `ify` functions in `resolver.ts` have been replaced with a new function `replaceFileExt`. 

This work is done in support of issue #76 