### PR TITLE
rm cachebuster for all files non-app entry and API

### DIFF
--- a/src/ast/ultra.ts
+++ b/src/ast/ultra.ts
@@ -4,7 +4,7 @@ import {
   StringLiteral,
   Visitor,
 } from "../deps.ts";
-import { cacheBuster, isRemoteSource, isVendorSource } from "../resolver.ts";
+import { isRemoteSource, isVendorSource, replaceFileExt } from "../resolver.ts";
 import { ImportMapResolver } from "../importMapResolver.ts";
 import { root, vendorDirectory } from "../env.ts";
 
@@ -59,10 +59,7 @@ export class UltraVisitor extends Visitor {
     }
 
     if (!isRemoteSource(node.value)) {
-      node.value = cacheBuster(
-        node.value,
-        this.cacheTimestamp,
-      );
+      node.value = replaceFileExt(node.value, ".js");
     }
 
     //@ts-ignore StringLiteral missing raw field

--- a/src/ast/ultra.ts
+++ b/src/ast/ultra.ts
@@ -11,7 +11,6 @@ import { root, vendorDirectory } from "../env.ts";
 export class UltraVisitor extends Visitor {
   constructor(
     private importMapResolver: ImportMapResolver,
-    private cacheTimestamp?: number,
     private relativePrefix?: string,
     private sourceUrl?: URL,
   ) {

--- a/src/render.ts
+++ b/src/render.ts
@@ -66,7 +66,10 @@ const render = async (
   // FIXME: when using vendor import maps, and in dev mode, the server render fails
   // this will detect if using vendor map and disable dynamically imported app.
   if (isDev && importMap?.imports?.["react"]?.indexOf(".ultra") < 0) {
-    transpiledAppImportUrl.searchParams.set("ts", String(+new Date()));
+    transpiledAppImportUrl.searchParams.set(
+      "ts",
+      String(Math.ceil(+new Date() / 100)),
+    );
     importedApp = await import(transpiledAppImportUrl.toString());
   }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,6 +8,7 @@ import { isDev, sourceDirectory } from "./env.ts";
 import type { ImportMap, Navigate, RenderOptions } from "./types.ts";
 import { ImportMapResolver } from "./importMapResolver.ts";
 import { encodeStream, pushBody } from "./stream.ts";
+import { cacheBuster } from "./resolver.ts";
 
 // Size of the chunk to emit to the connection as the response streams:
 const defaultChunkSize = 8 * 1024;
@@ -66,11 +67,7 @@ const render = async (
   // FIXME: when using vendor import maps, and in dev mode, the server render fails
   // this will detect if using vendor map and disable dynamically imported app.
   if (isDev && importMap?.imports?.["react"]?.indexOf(".ultra") < 0) {
-    transpiledAppImportUrl.searchParams.set(
-      "ts",
-      String(Math.ceil(+new Date() / 100)),
-    );
-    importedApp = await import(transpiledAppImportUrl.toString());
+    importedApp = await import(cacheBuster(transpiledAppImportUrl));
   }
 
   // kickstart caches for react-helmet and swr

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -38,13 +38,13 @@ export const resolveFileUrl = (from: string, to: string) => {
   return new URL(toFileUrl(resolve(from, to)).toString());
 };
 
-export const cacheBuster = (source: string, timestamp?: number): string => {
-  return source.replace(
-    /\.(j|t)sx?/gi,
-    () => {
-      return `.js${timestamp ? `?ts=${timestamp}` : ""}`;
-    },
+export const cacheBuster = (url: URL): string => {
+  const buster = Math.ceil(+new Date() / 100);
+  url.searchParams.set(
+    "ts",
+    String(buster),
   );
+  return url.toString();
 };
 
 export const isRemoteSource = (value: string): boolean => {

--- a/src/server/requestHandler.ts
+++ b/src/server/requestHandler.ts
@@ -110,7 +110,6 @@ export function createRequestHandler(options: CreateRequestHandlerOptions) {
           source,
           sourceUrl: requestUrl,
           importMap,
-          cacheBuster,
         });
 
         const t1 = performance.now();

--- a/src/server/requestHandler.ts
+++ b/src/server/requestHandler.ts
@@ -3,6 +3,7 @@ import { LRU, readableStreamFromReader } from "../deps.ts";
 import { disableStreaming, lang, root } from "../env.ts";
 import render from "../render.ts";
 import {
+  cacheBuster,
   replaceFileExt,
   resolveFileUrl,
   stripTrailingSlash,
@@ -29,7 +30,6 @@ export function createRequestHandler(options: CreateRequestHandlerOptions) {
   } = options;
 
   const memory = new LRU(500);
-  const serverStart = Math.ceil(+new Date() / 100);
   const listeners = new Set<WebSocket>();
 
   // async file watcher to send socket messages
@@ -48,8 +48,6 @@ export function createRequestHandler(options: CreateRequestHandlerOptions) {
   }
 
   return async function requestHandler(request: Request): Promise<Response> {
-    const requestStart = Math.ceil(+new Date() / 100);
-    const cacheBuster = isDev ? requestStart : serverStart;
     const { raw, transpile } = await assets(sourceDirectory);
     const vendor = await assets(`.ultra/${vendorDirectory}`);
     const requestUrl = new URL(request.url);
@@ -138,7 +136,7 @@ export function createRequestHandler(options: CreateRequestHandlerOptions) {
         } else if (apiPaths.has(`${path}/index.ts`)) {
           path = `file://${cwd}/${path}/index.ts`;
         }
-        return (await import(`${path}?ts=${cacheBuster}`)).default;
+        return (await import(cacheBuster(new URL(path)))).default;
       };
       try {
         const pathname = stripTrailingSlash(requestUrl.pathname);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -22,13 +22,11 @@ const parserOptions: ParseOptions = {
 export const transformSource = async (
   options: TransformOptions,
 ): Promise<string> => {
-  const { source, sourceUrl, importMap, cacheBuster, minify, relativePrefix } =
-    options;
+  const { source, sourceUrl, importMap, minify, relativePrefix } = options;
 
   const importMapResolver = new ImportMapResolver(importMap, sourceUrl);
   const visitor = new UltraVisitor(
     importMapResolver,
-    cacheBuster,
     relativePrefix,
     sourceUrl,
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@ export type TransformOptions = {
   source: string;
   sourceUrl: URL;
   importMap: ImportMap;
-  cacheBuster?: number;
   minify?: boolean;
   relativePrefix?: string;
 };


### PR DESCRIPTION
Only the app entry and API routes need cache-busting strategy, the other ESM doesn't seem to need it, so I've removed them. This makes the project a lot simpler, especially for preload headers.