### PR TITLE
rm `root` from deno server and request handlers

### DIFF
--- a/src/ast/ultra.ts
+++ b/src/ast/ultra.ts
@@ -54,7 +54,7 @@ export class UltraVisitor extends Visitor {
         this.relativePrefix,
       );
     } else if (isVendorSource(node.value, vendorDirectory)) {
-      node.value = this?.sourceUrl?.host + `/${vendorDirectory}/` +
+      node.value = this?.sourceUrl?.origin + `/${vendorDirectory}/` +
         node.value.split(`.ultra/${vendorDirectory}/`)[1];
     }
 

--- a/src/ast/ultra.ts
+++ b/src/ast/ultra.ts
@@ -6,7 +6,7 @@ import {
 } from "../deps.ts";
 import { isRemoteSource, isVendorSource, replaceFileExt } from "../resolver.ts";
 import { ImportMapResolver } from "../importMapResolver.ts";
-import { root, vendorDirectory } from "../env.ts";
+import { vendorDirectory } from "../env.ts";
 
 export class UltraVisitor extends Visitor {
   constructor(
@@ -54,7 +54,7 @@ export class UltraVisitor extends Visitor {
         this.relativePrefix,
       );
     } else if (isVendorSource(node.value, vendorDirectory)) {
-      node.value = root + `/${vendorDirectory}/` +
+      node.value = this?.sourceUrl?.host + `/${vendorDirectory}/` +
         node.value.split(`.ultra/${vendorDirectory}/`)[1];
     }
 

--- a/src/deno/server.ts
+++ b/src/deno/server.ts
@@ -5,7 +5,6 @@ import { ImportMap } from "./../types.ts";
 
 const sourceDirectory = Deno.env.get("source") || "src";
 const vendorDirectory = Deno.env.get("vendor") || "x";
-const root = Deno.env.get("root") || "http://localhost:8000";
 const lang = Deno.env.get("lang") || "en";
 const disableStreaming = Deno.env.get("disableStreaming") || 0;
 
@@ -17,6 +16,12 @@ const deploy = async () => {
 
   const handler = async (request: Request) => {
     const url = new URL(request.url);
+
+    const xForwardedProto = request.headers.get("x-forwarded-proto");
+    if (xForwardedProto) url.protocol = xForwardedProto + ":";
+
+    const xForwardedHost = request.headers.get("x-forwarded-host");
+    if (xForwardedHost) url.hostname = xForwardedHost;
 
     //API//
 
@@ -58,7 +63,6 @@ const deploy = async () => {
     return new Response(
       await render({
         url,
-        root,
         importMap: denoMap,
         lang,
         disableStreaming: !!disableStreaming,

--- a/src/render.ts
+++ b/src/render.ts
@@ -24,7 +24,6 @@ const requiredDependencies = [
 const render = async (
   {
     url,
-    root,
     importMap,
     lang = "en",
     disableStreaming = false,
@@ -44,7 +43,7 @@ const render = async (
 
   const importMapResolver = new ImportMapResolver(
     renderMap,
-    new URL(sourceDirectory, root),
+    new URL(sourceDirectory, url.origin),
   );
 
   const dependencyMap = importMapResolver.getDependencyMap(
@@ -119,7 +118,7 @@ const render = async (
           .map((i) => helmet[i].toString())
           .join("")
       }<script type="module" defer>${
-        isDev ? socket(root) : ""
+        isDev ? socket(url) : ""
       }import { createElement } from "${
         dependencyMap.get("react")
       }";import { hydrateRoot } from "${
@@ -208,8 +207,7 @@ const staticLocationHook = (
   return hook;
 };
 
-const socket = (root: string) => {
-  const url = new URL(root);
+const socket = (url: URL) => {
   return `
     const _ultra_socket = new WebSocket("ws://${url.host}/_ultra_socket");
     _ultra_socket.addEventListener("message", (e) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { serve } from "./deps.ts";
-import { isDev, port, root, sourceDirectory, vendorDirectory } from "./env.ts";
+import { isDev, port, sourceDirectory, vendorDirectory } from "./env.ts";
 import { resolveConfig, resolveImportMap } from "./config.ts";
 import { createRequestHandler } from "./server/requestHandler.ts";
 
@@ -18,7 +18,7 @@ const server = () => {
     isDev,
   });
 
-  console.log(`Ultra running ${root}`);
+  console.log(`Ultra running http://localhost:${port}`);
 
   return serve(requestHandler, { port: +port });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,6 @@ export type Ultraloader = {
 };
 
 export type RenderOptions = {
-  root: string;
   importMap: ImportMap;
   url: URL;
   lang: string;

--- a/src/unstable/server.ts
+++ b/src/unstable/server.ts
@@ -1,4 +1,4 @@
-import { isDev, port, root, sourceDirectory, vendorDirectory } from "../env.ts";
+import { isDev, port, sourceDirectory, vendorDirectory } from "../env.ts";
 import { resolveConfig, resolveImportMap } from "../config.ts";
 import { serve } from "../deps.ts";
 import { createRequestHandler } from "./server/requestHandler.ts";
@@ -43,7 +43,7 @@ export function unstable_ultra<T extends AppProps>(
     isDev,
   });
 
-  console.log(`Ultra running ${root}`);
+  console.log(`Ultra running http://localhost:${port}`);
 
   return serve(requestHandler, { port: +port });
 }


### PR DESCRIPTION
This removes the need for a `root` env to be set, mainly effects prod deployments, and should remove the need to set one for Deno Deploy.