### PR TITLE
tests: Deno.run the actual entrypoint

### DIFF
--- a/src/oak/handler.ts
+++ b/src/oak/handler.ts
@@ -8,7 +8,7 @@ const cwd = Deno.cwd();
 const config = await resolveConfig(cwd);
 const importMap = await resolveImportMap(cwd, config);
 
-const requestHandler = createRequestHandler({
+const requestHandler = await createRequestHandler({
   cwd,
   importMap,
   paths: {

--- a/workspace/oak.ts
+++ b/workspace/oak.ts
@@ -7,7 +7,7 @@ const app = new Application();
 const router = new Router();
 
 router.get("/custom-route", (context) => {
-  context.response.body = "#1";
+  context.response.body = "Oak custom route!";
 });
 
 app.use(router.routes());

--- a/workspace/tests/helpers.ts
+++ b/workspace/tests/helpers.ts
@@ -2,9 +2,9 @@ import puppeteer from "https://deno.land/x/puppeteer@9.0.2/mod.ts";
 import { join } from "https://deno.land/std@0.135.0/path/mod.ts";
 import { readLines } from "https://deno.land/std@0.135.0/io/mod.ts";
 
-export async function startTestServer(taskName = "start") {
+export async function startTestServer(entrypoint: string) {
   const serverProcess = Deno.run({
-    cmd: ["deno", "task", taskName],
+    cmd: ["deno", "run", "-A", "--unstable", "--no-check", entrypoint],
     cwd: join(Deno.cwd(), "./workspace"),
     stdout: "piped",
     stderr: "piped",
@@ -18,18 +18,17 @@ export async function startTestServer(taskName = "start") {
   for await (const line of readLines(serverProcess.stdout)) {
     if (line.includes("Ultra running")) {
       console.log(line);
-
-      return {
-        close() {
-          serverProcess.stderr.close();
-          serverProcess.stdout.close();
-          serverProcess.close();
-        },
-      };
+      break;
     }
   }
 
-  serverProcess.close();
+  return {
+    async close() {
+      await serverProcess.stdout.close();
+      await serverProcess.stderr.close();
+      await serverProcess.close();
+    },
+  };
 }
 
 export async function launchLocalhostBrowser() {

--- a/workspace/tests/workspace_home.test.ts
+++ b/workspace/tests/workspace_home.test.ts
@@ -27,7 +27,7 @@ async function assertExpectedPageElements(page: Page) {
 }
 
 Deno.test("puppeteer: native server", async (t) => {
-  const server = await startTestServer();
+  const server = await startTestServer("server.js");
   const browser = await launchLocalhostBrowser();
 
   await t.step(
@@ -52,7 +52,7 @@ Deno.test("puppeteer: native server", async (t) => {
 });
 
 Deno.test("puppeteer: oak server", async (t) => {
-  const server = await startTestServer("start:oak");
+  const server = await startTestServer("oak.ts");
   const browser = await launchLocalhostBrowser();
 
   await t.step(

--- a/workspace/tests/workspace_home.test.ts
+++ b/workspace/tests/workspace_home.test.ts
@@ -1,4 +1,5 @@
 import {
+  assert,
   assertEquals,
   fail,
 } from "https://deno.land/std@0.135.0/testing/asserts.ts";
@@ -48,7 +49,7 @@ Deno.test("puppeteer: native server", async (t) => {
   );
 
   await browser.close();
-  server?.close();
+  await server.close();
 });
 
 Deno.test("puppeteer: oak server", async (t) => {
@@ -72,6 +73,21 @@ Deno.test("puppeteer: oak server", async (t) => {
     },
   );
 
+  await t.step("Should handle custom-route", async () => {
+    try {
+      const page = await browser.newPage();
+      await page.setViewport({ width: 979, height: 865 });
+      await page.goto("http://localhost:8000/custom-route", {
+        waitUntil: "networkidle0",
+      });
+
+      const content = await page.content();
+      assert(content.includes("Oak custom route!"));
+    } catch (error) {
+      throw error;
+    }
+  });
+
   await browser.close();
-  server?.close();
+  await server.close();
 });


### PR DESCRIPTION
Fixes the issue where the server processes weren't closing due to using Deno.run with deno tasks, which was creating child processes.

Changes to Deno.run the server entrypoints directly.