### PR TITLE
chore: Upgrade Puppeteer 9.0.2->14.1.1

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -27,7 +27,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -40,12 +40,12 @@ jobs:
 
       - name: Run linter
         run: deno lint
-      
+
       - name: Run tests
-        run: deno task test 
+        run: deno task test
 
       - name: Setup Chrome
-        run: deno run -A --unstable https://deno.land/x/puppeteer@9.0.2/install.ts
+        run: deno run -A --unstable https://deno.land/x/puppeteer@14.1.1/install.ts
 
       - name: Run puppeteer tests
         run: deno task test:puppeteer

--- a/workspace/tests/helpers.ts
+++ b/workspace/tests/helpers.ts
@@ -1,4 +1,4 @@
-import puppeteer from "https://deno.land/x/puppeteer@9.0.2/mod.ts";
+import puppeteer from "https://deno.land/x/puppeteer@14.1.1/mod.ts";
 import { join } from "https://deno.land/std@0.135.0/path/mod.ts";
 import { readLines } from "https://deno.land/std@0.135.0/io/mod.ts";
 

--- a/workspace/tests/workspace_home.test.ts
+++ b/workspace/tests/workspace_home.test.ts
@@ -17,7 +17,7 @@ const expectations = [
 // over and over on Windows specifically. I split out steps
 // into their own tests for this reason.
 
-async function assertExpectedPageElements(page: Page) {
+async function assertExpectedPageElements(page: Page): Promise<void> {
   for (const expected of expectations) {
     const selection = await page.waitForSelector(expected.selector);
     if (selection) {

--- a/workspace/tests/workspace_home.test.ts
+++ b/workspace/tests/workspace_home.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   fail,
 } from "https://deno.land/std@0.135.0/testing/asserts.ts";
-import { Page } from "https://deno.land/x/puppeteer@9.0.2/mod.ts";
+import { Page } from "https://deno.land/x/puppeteer@14.1.1/mod.ts";
 import { launchLocalhostBrowser, startTestServer } from "./helpers.ts";
 
 const expectations = [
@@ -14,7 +14,7 @@ const expectations = [
 
 // NOTES: (OM)
 // Puppeteer tests, when split into async steps, can fail
-// over and over on windows specifically. I split out steps
+// over and over on Windows specifically. I split out steps
 // into their own tests for this reason.
 
 async function assertExpectedPageElements(page: Page) {


### PR DESCRIPTION
This PR upgrades Puppeteer used in our e2e tests from v9.0.2 to v14.1.1