### PR TITLE
Hash static assets

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -159,7 +159,7 @@ export default async function build(
   /**
    * Create the asset manifest
    */
-  await assetManifest(buildContext);
+  const assets = await assetManifest(buildContext);
 
   /**
    * Patch deno.json with required options
@@ -178,6 +178,7 @@ export default async function build(
     options: resolvedOptions,
     paths,
     importMap,
+    assetManifest: assets,
     denoConfig,
     files: buildContext.files,
   };

--- a/build.ts
+++ b/build.ts
@@ -26,6 +26,7 @@ import type {
   BuildResult,
 } from "./lib/build/types.ts";
 import { createBuildContext } from "./lib/build/context.ts";
+import { assetManifest } from "./lib/build/assetManifest.ts";
 
 /**
  * Re-export these types as convenience to build plugin authors
@@ -102,7 +103,7 @@ export default async function build(
    */
   spinner.text = sprintf(
     "Copying source from: %s to %s",
-    cwdRelative(buildContext.paths.rootDir),
+    buildContext.paths.rootDir,
     cwdRelative(buildContext.paths.outputDir),
   );
   await copySource(buildContext);
@@ -154,6 +155,11 @@ export default async function build(
     paths.resolveOutputFileUrl("importMap.production.json"),
     importMap,
   );
+
+  /**
+   * Create the asset manifest
+   */
+  await assetManifest(buildContext);
 
   /**
    * Patch deno.json with required options
@@ -210,6 +216,8 @@ export default async function build(
       Alternatively, you can cd into "${brightBlue(output)}" and run: ${underline("deno task start")}
     `);
   }
+
+  buildContext.graph?.free();
 
   return finalBuildResult;
 }

--- a/client.js
+++ b/client.js
@@ -1,1 +1,2 @@
 export { useFlushEffects } from "./lib/client/flush-effects.js";
+export { AssetProvider, useAsset } from "./lib/client/asset.js";

--- a/client.js
+++ b/client.js
@@ -1,2 +1,2 @@
 export { useFlushEffects } from "./lib/client/flush-effects.js";
-export { AssetProvider, useAsset } from "./lib/client/asset.js";
+export { useAsset } from "./lib/client/asset.js";

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -1,3 +1,5 @@
+import { useAsset } from "ultra/client.js";
+
 export default function App() {
   console.log("Hello world!");
   return (
@@ -6,8 +8,8 @@ export default function App() {
         <meta charSet="utf-8" />
         <title>basic</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="shortcut icon" href="/favicon.ico" />
-        <link rel="stylesheet" href="/style.css" />
+        <link rel="shortcut icon" href={useAsset("/favicon.ico")} />
+        <link rel="stylesheet" href={useAsset("/style.css")} />
       </head>
       <body>
         <main>

--- a/lib/build/assetManifest.ts
+++ b/lib/build/assetManifest.ts
@@ -1,0 +1,50 @@
+import { hash } from "../utils/hash.ts";
+import { writeJsonFile } from "../utils/json.ts";
+import { globToRegExp, join } from "./deps.ts";
+import type { BuildContext } from "./types.ts";
+import { addFileContentHash } from "./utils/path.ts";
+
+export async function assetManifest(context: BuildContext) {
+  const PUBLIC_ASSET_REGEX = globToRegExp(
+    join(context.paths.outputDir, "public", "**", "*"),
+    {
+      extended: true,
+      globstar: true,
+      caseInsensitive: false,
+    },
+  );
+
+  const publicDir = context.paths.resolveBuildPath("public");
+  const assets = new Map<string, string>();
+
+  for (const [source, outputPath] of context.files.entries()) {
+    if (PUBLIC_ASSET_REGEX.test(outputPath)) {
+      const content = await Deno.readFile(source);
+      const sourceHash = await hash(content);
+
+      /**
+       * Strip publicDir from the path to get the absolute
+       * url to the asset.
+       */
+      const publicUrl = outputPath.replace(publicDir, "");
+      const hashedPublicUrl = addFileContentHash(publicUrl, sourceHash);
+
+      await Deno.rename(
+        outputPath,
+        outputPath.replace(publicUrl, hashedPublicUrl),
+      );
+
+      assets.set(publicUrl, hashedPublicUrl);
+    }
+  }
+
+  /**
+   * Write the asset-manifest.json to the build output
+   */
+  await writeJsonFile(
+    context.paths.resolveBuildPath("asset-manifest.json"),
+    Array.from(assets.entries()),
+  );
+
+  return assets;
+}

--- a/lib/build/compileSources.ts
+++ b/lib/build/compileSources.ts
@@ -1,8 +1,8 @@
 import type {
   Module,
 } from "https://deno.land/x/deno_graph@0.31.0/lib/types.d.ts";
-import { extname } from "../deps.ts";
 import { hash } from "../utils/hash.ts";
+import { addFileContentHash } from "./utils/path.ts";
 import { fromFileUrl } from "./deps.ts";
 import type { BuildContext } from "./types.ts";
 
@@ -51,10 +51,8 @@ export async function compileSources(
 }
 
 async function getModuleOutputPath(module: Module) {
-  let outputPath = fromFileUrl(module.specifier);
+  const outputPath = fromFileUrl(module.specifier);
   const sourceHash = await hash(module.source);
-  const extension = extname(outputPath);
-  outputPath = outputPath.replace(extension, `.${sourceHash}${extension}`);
 
-  return outputPath;
+  return addFileContentHash(outputPath, sourceHash);
 }

--- a/lib/build/resolvePaths.ts
+++ b/lib/build/resolvePaths.ts
@@ -12,6 +12,7 @@ export function resolvePaths(
   options: ResolvePathsOptions,
 ) {
   const rootDir = Deno.cwd();
+  const publicDir = join(rootDir, "public");
   const outputDir = join(rootDir, dest);
 
   const browserEntrypoint = relative(
@@ -27,6 +28,7 @@ export function resolvePaths(
   return {
     rootDir,
     outputDir,
+    publicDir,
     entrypoint: {
       browser: browserEntrypoint,
       server: serverEntrypoint,
@@ -34,6 +36,12 @@ export function resolvePaths(
     output: {
       browser: join(outputDir, browserEntrypoint),
       server: join(outputDir, serverEntrypoint),
+    },
+    resolveBuildPath(path: string) {
+      return join(outputDir, path);
+    },
+    resolvePublicPath(path: string) {
+      return join(outputDir, publicDir, path);
     },
     resolveOutputFileUrl(path: string) {
       return toFileUrl(join(outputDir, path));

--- a/lib/build/types.ts
+++ b/lib/build/types.ts
@@ -53,6 +53,7 @@ export type BuildResult = {
   denoConfig: DenoConfig;
   paths: ResolvedPaths;
   importMap: ImportMap;
+  assetManifest: Map<string, string>;
   /**
    * A map of files with the source path as the key
    * and the output path as the value.

--- a/lib/build/utils/path.ts
+++ b/lib/build/utils/path.ts
@@ -1,0 +1,8 @@
+import { extname } from "../../deps.ts";
+
+export function addFileContentHash(path: string, hash: string) {
+  const extension = extname(path);
+  path = path.replace(extension, `.${hash}${extension}`);
+
+  return path;
+}

--- a/lib/client/asset.js
+++ b/lib/client/asset.js
@@ -1,39 +1,14 @@
-import { createContext, createElement as h, useContext, useMemo } from "react";
-import { useFlushEffects } from "./flush-effects.js";
+import { createContext, useContext, useMemo } from "react";
 
 /**
  * @type {React.Context<undefined | Map<string, string>>}
  */
-const AssetContext = createContext(undefined);
-
-/**
- * @typedef {Object} AssetProviderProps
- * @property {Map<string, string>} value
- * @property {React.ReactNode} [children]
- */
-
-/**
- * @param {AssetProviderProps} props
- */
-export function AssetProvider(props) {
-  useFlushEffects(() => {
-    return h("script", {
-      type: "text/javascript",
-      dangerouslySetInnerHTML: {
-        __html: `window.__ULTRA_ASSET_MAP = ${
-          JSON.stringify(Array.from(props.value.entries()))
-        }`,
-      },
-    });
-  });
-
-  return h(AssetContext.Provider, { value: props.value }, props.children);
-}
+export const AssetContext = createContext(undefined);
 
 /**
  * @param {string} path
  */
 export function useAsset(path) {
   const context = useContext(AssetContext) || new Map(window.__ULTRA_ASSET_MAP);
-  return useMemo(() => context.get(path) || path, [path]);
+  return useMemo(() => context.get(path) || path, [path, context]);
 }

--- a/lib/client/asset.js
+++ b/lib/client/asset.js
@@ -1,0 +1,39 @@
+import { createContext, createElement as h, useContext, useMemo } from "react";
+import { useFlushEffects } from "./flush-effects.js";
+
+/**
+ * @type {React.Context<undefined | Map<string, string>>}
+ */
+const AssetContext = createContext(undefined);
+
+/**
+ * @typedef {Object} AssetProviderProps
+ * @property {Map<string, string>} value
+ * @property {React.ReactNode} [children]
+ */
+
+/**
+ * @param {AssetProviderProps} props
+ */
+export function AssetProvider(props) {
+  useFlushEffects(() => {
+    return h("script", {
+      type: "text/javascript",
+      dangerouslySetInnerHTML: {
+        __html: `window.__ULTRA_ASSET_MAP = ${
+          JSON.stringify(Array.from(props.value.entries()))
+        }`,
+      },
+    });
+  });
+
+  return h(AssetContext.Provider, { value: props.value }, props.children);
+}
+
+/**
+ * @param {string} path
+ */
+export function useAsset(path) {
+  const context = useContext(AssetContext) || new Map(window.__ULTRA_ASSET_MAP);
+  return useMemo(() => context.get(path) || path, [path]);
+}

--- a/lib/render.tsx
+++ b/lib/render.tsx
@@ -6,11 +6,13 @@ import {
 } from "react-dom/server";
 import { fromFileUrl } from "./deps.ts";
 import { FlushEffectsContext } from "./client/flush-effects.js";
+import { AssetProvider } from "./client/asset.js";
 import { continueFromInitialStream, renderToInitialStream } from "./stream.ts";
 import { ImportMap } from "./types.ts";
 
 type RenderToStreamOptions = RenderToReadableStreamOptions & {
   importMap: ImportMap;
+  assetManifest: Map<string, string>;
   generateStaticHTML?: boolean;
   flushEffectsToHead?: boolean;
 };
@@ -23,6 +25,7 @@ export async function renderToStream(
     generateStaticHTML = false,
     flushEffectsToHead = true,
     importMap,
+    assetManifest,
   } = options;
 
   /**
@@ -64,7 +67,11 @@ export async function renderToStream(
   };
 
   const renderStream = await renderToInitialStream({
-    element: <FlushEffects children={Component} />,
+    element: (
+      <FlushEffects>
+        <AssetProvider value={assetManifest} children={Component} />
+      </FlushEffects>
+    ),
     options,
   });
 

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -1,5 +1,13 @@
 import { ULTRA_COMPILER_PATH, ULTRA_STATIC_PATH } from "./constants.ts";
-import { assert, dirname, fromFileUrl, Hono, resolve, wait } from "./deps.ts";
+import {
+  assert,
+  dirname,
+  fromFileUrl,
+  Hono,
+  resolve,
+  toFileUrl,
+  wait,
+} from "./deps.ts";
 import { serveCompiled } from "./middleware/serveCompiled.ts";
 import { serveStatic } from "./middleware/serveStatic.ts";
 import { CreateServerOptions, Mode } from "./types.ts";
@@ -32,7 +40,8 @@ export async function createServer(
 
   const root = fromFileUrl(dirname(browserEntrypoint));
   const importMapPath = resolveImportMapPath(mode, root, options.importMapPath);
-  const assetManifestPath = resolve(root, "asset-manifest.json");
+  const assetManifestPath =
+    toFileUrl(resolve(root, "asset-manifest.json")).href;
 
   const server = new UltraServer(
     root,

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -32,7 +32,15 @@ export async function createServer(
 
   const root = fromFileUrl(dirname(browserEntrypoint));
   const importMapPath = resolveImportMapPath(mode, root, options.importMapPath);
-  const server = new UltraServer(root, mode, importMapPath, browserEntrypoint);
+  const assetManifestPath = resolve(root, "asset-manifest.json");
+
+  const server = new UltraServer(
+    root,
+    mode,
+    importMapPath,
+    assetManifestPath,
+    browserEntrypoint,
+  );
 
   await server.init();
 

--- a/lib/ultra.ts
+++ b/lib/ultra.ts
@@ -33,9 +33,12 @@ export class UltraServer extends Hono {
     /**
      * Parse the provided asset manifest
      */
-    this.assetManifest = this.mode === "production"
-      ? await this.#parseJsonFile(this.assetManifestPath)
-      : this.assetManifest;
+    const assetManifest: [string, string][] | undefined =
+      this.mode === "production"
+        ? await this.#parseJsonFile(this.assetManifestPath)
+        : undefined;
+
+    this.assetManifest = assetManifest ? new Map(assetManifest) : new Map();
 
     /**
      * Prepare the entrypoint

--- a/lib/ultra.ts
+++ b/lib/ultra.ts
@@ -11,11 +11,13 @@ type UltraServerRenderOptions = {
 
 export class UltraServer extends Hono {
   public importMap: ImportMap | undefined;
+  public assetManifest: Map<string, string> = new Map();
 
   constructor(
     public root: string,
     public mode: Mode,
     public importMapPath: string,
+    public assetManifestPath: string,
     public entrypoint: string,
   ) {
     super();
@@ -26,12 +28,19 @@ export class UltraServer extends Hono {
     /**
      * Parse the provided importMap
      */
-    this.importMap = await this.#parseImportMap(this.importMapPath);
+    this.importMap = await this.#parseJsonFile(this.importMapPath);
+
+    /**
+     * Parse the provided asset manifest
+     */
+    this.assetManifest = this.mode === "production"
+      ? await this.#parseJsonFile(this.assetManifestPath)
+      : this.assetManifest;
 
     /**
      * Prepare the entrypoint
      */
-    this.entrypoint = this.#prepareEntrypoint(this.importMap);
+    this.entrypoint = this.#prepareEntrypoint(this.importMap!);
   }
 
   render(Component: ReactElement, options?: UltraServerRenderOptions) {
@@ -40,13 +49,14 @@ export class UltraServer extends Hono {
     }
 
     return renderToStream(Component, {
+      assetManifest: this.assetManifest,
       importMap: this.importMap,
       bootstrapModules: [this.entrypoint],
       ...options,
     });
   }
 
-  async #parseImportMap(path: string): Promise<ImportMap> {
+  async #parseJsonFile<T>(path: string): Promise<T> {
     const bytes = await fetch(path).then((response) => response.arrayBuffer());
     const content = new TextDecoder().decode(bytes);
 

--- a/lib/utils/hash.ts
+++ b/lib/utils/hash.ts
@@ -3,8 +3,11 @@
  * @param value The string to create a hash of, this is usually the file content.
  * @param length The length of the resulting hash to return
  */
-export async function hash(value: string, length = 8) {
-  const msgUint8 = new TextEncoder().encode(value);
+export async function hash(value: string | Uint8Array, length = 8) {
+  const msgUint8 = typeof value === "string"
+    ? new TextEncoder().encode(value)
+    : value;
+
   const hashBuffer = await crypto.subtle.digest("SHA-256", msgUint8);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join(


### PR DESCRIPTION
This PR adds `asset-manifest.json` generation during build, it also adds a new client side hook `useAsset` which will use the generated asset manifest to lookup the hashed filename.

eg.

```ts
// In production would return something like "/styles.4h443h.css"
const styles = useAsset("/styles.css");
```