### PR TITLE
wip: trigger reload in dev

### DIFF
--- a/dev.ts
+++ b/dev.ts
@@ -1,0 +1,22 @@
+import {
+  join,
+  SEP,
+  toFileUrl,
+} from "https://deno.land/std@0.153.0/path/mod.ts";
+
+const cwd = join(Deno.cwd(), SEP);
+const watcher = Deno.watchFs(cwd);
+
+const mainWorker = new Worker(
+  new URL(Deno.args[0], toFileUrl(cwd)).href,
+  {
+    type: "module",
+    name: "main",
+  },
+);
+
+for await (const event of watcher) {
+  if (event.kind === "modify") {
+    mainWorker.postMessage({ type: "reload" });
+  }
+}

--- a/examples/basic/deno.json
+++ b/examples/basic/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A --no-check --watch ./server.tsx",
+    "dev": "deno run -A --no-check ../../dev.ts ./server.tsx",
     "build": "deno run -A ./build.ts",
     "start": "ULTRA_MODE=production deno run -A --no-remote ./server.js"
   },

--- a/examples/basic/server.tsx
+++ b/examples/basic/server.tsx
@@ -7,6 +7,8 @@ const server = await createServer({
   browserEntrypoint: import.meta.resolve("./client.tsx"),
 });
 
+console.log(import.meta.url);
+
 server.get("*", async (context) => {
   /**
    * Render the request

--- a/examples/basic/server.tsx
+++ b/examples/basic/server.tsx
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.153.0/http/server.ts";
-import { createServer } from "ultra/server.ts";
+import { createServer } from "../../server.ts";
 import App from "./src/app.tsx";
 
 const server = await createServer({

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -1,7 +1,36 @@
 import useAsset from "ultra/hooks/use-asset.js";
 
+function LiveReload() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+          console.log("Connecting to dev server...");
+          try {
+            const ws = new WebSocket("ws://localhost:8000");
+            ws.onopen = () => {
+              console.log('Connected')
+            };
+            ws.onmessage = (message) => {
+              const data = message?.data ? JSON.parse(message.data) : undefined;
+              if (data) {
+                console.log(data)
+              }
+            };
+            ws.onclose = () => {
+              console.log("Disconnected from dev server...");
+            }
+          } catch (error) {
+            console.error(error)
+          }
+        `,
+      }}
+    >
+    </script>
+  );
+}
+
 export default function App() {
-  console.log("Hello world!");
   return (
     <html lang="en">
       <head>
@@ -34,6 +63,7 @@ export default function App() {
             libraries.
           </p>
         </main>
+        <LiveReload />
       </body>
     </html>
   );

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -16,8 +16,10 @@ function LiveReload() {
             ws.onmessage = (message) => {
               const data = message?.data ? JSON.parse(message.data) : undefined;
               if (data) {
-                console.log(data)
-                window.location.reload()
+                console.log(data);
+                setTimeout(() => {
+                  window.location.reload();
+                }, 1000);
               }
             };
             

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -5,24 +5,28 @@ function LiveReload() {
     <script
       dangerouslySetInnerHTML={{
         __html: `
-          console.log("Connecting to dev server...");
-          try {
+          function connect() {
+            console.log("Connecting to dev server...");
             const ws = new WebSocket("ws://localhost:8000");
+
             ws.onopen = () => {
               console.log('Connected')
             };
+            
             ws.onmessage = (message) => {
               const data = message?.data ? JSON.parse(message.data) : undefined;
               if (data) {
                 console.log(data)
+                window.location.reload()
               }
             };
-            ws.onclose = () => {
-              console.log("Disconnected from dev server...");
+            
+            ws.onerror = () => {
+              console.error('Socket encountered error: ', err.message, 'Closing socket');
+              ws.close();
             }
-          } catch (error) {
-            console.error(error)
           }
+          connect()
         `,
       }}
     >

--- a/hooks/use-asset.js
+++ b/hooks/use-asset.js
@@ -14,6 +14,8 @@ export default function useAsset(path) {
   // Ensure we are using a relative path
   path = path.startsWith("/") ? `.${path}` : path;
 
-  const context = useContext(AssetContext) || new Map(window.__ULTRA_ASSET_MAP);
+  const context = useContext(AssetContext) ||
+    new Map(globalThis.__ULTRA_ASSET_MAP);
+
   return useMemo(() => context.get(path) || path, [path]);
 }

--- a/lib/middleware/dev.ts
+++ b/lib/middleware/dev.ts
@@ -1,0 +1,15 @@
+import type { Context, Next } from "../types.ts";
+
+export async function dev(context: Context, next: Next) {
+  if (context.req.headers.get("upgrade") != "websocket") {
+    await next();
+  } else {
+    const { socket: ws, response } = Deno.upgradeWebSocket(context.req);
+
+    globalThis.onmessage = (event) => {
+      ws.send(JSON.stringify(event.data));
+    };
+
+    return response;
+  }
+}

--- a/lib/middleware/dev.ts
+++ b/lib/middleware/dev.ts
@@ -6,8 +6,14 @@ export async function dev(context: Context, next: Next) {
   } else {
     const { socket: ws, response } = Deno.upgradeWebSocket(context.req);
 
-    globalThis.onmessage = (event) => {
-      ws.send(JSON.stringify(event.data));
+    globalThis.onmessage = async (event) => {
+      const data: { type: string; paths: string[] } = event.data;
+      for (const path of data.paths) {
+        console.log("import", path);
+        await import(path);
+      }
+      console.log("websocket send");
+      ws.send(JSON.stringify(data));
     };
 
     return response;

--- a/lib/middleware/dev.ts
+++ b/lib/middleware/dev.ts
@@ -6,12 +6,8 @@ export async function dev(context: Context, next: Next) {
   } else {
     const { socket: ws, response } = Deno.upgradeWebSocket(context.req);
 
-    globalThis.onmessage = async (event) => {
+    globalThis.onmessage = (event) => {
       const data: { type: string; paths: string[] } = event.data;
-      for (const path of data.paths) {
-        console.log("import", path);
-        await import(path);
-      }
       console.log("websocket send");
       ws.send(JSON.stringify(data));
     };

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -48,6 +48,7 @@ export async function createServer(
   if (mode === "development") {
     const spinner = wait("Loading compiler").start();
     const { compiler } = await import("./middleware/compiler.ts");
+    const { dev } = await import("./middleware/dev.ts");
     spinner.stop();
 
     server.use(
@@ -66,6 +67,8 @@ export async function createServer(
         cache: false,
       }),
     );
+
+    server.use("*", dev);
   } else {
     /**
      * Serve assets from "./public" at "/"


### PR DESCRIPTION
This is experimental, but adds a dev.ts in ultra root, the basic example is very roughly hooked up to use it.

Basically it uses the Worker api to start the server, and posts messages to it when files change in the current working directory `examples/basic`.

What works is that we can reload the browser, but the modules are still loaded in the worker, so the server still renders the previous, same issue we had with v1.

Wish there was a way to tell Deno to "reload" a module, or even if you "import" that module again it invalidates it or something...