### PR TITLE
feat: allow passing custom public root path in createServer

### DIFF
--- a/lib/build/types.ts
+++ b/lib/build/types.ts
@@ -53,6 +53,10 @@ export type BuildOptions = {
    */
   jsxImportSource?: string;
   /**
+   * The path to the public folder.
+   */
+  publicRoot?: string;
+  /**
    * A build plugin to run after completing the initial build
    *
    * @default undefined

--- a/lib/build/ultra.ts
+++ b/lib/build/ultra.ts
@@ -30,6 +30,7 @@ export class UltraBuilder extends Builder {
 
   public browserEntrypoint?: string;
   public serverEntrypoint: string;
+  public publicRoot?: string;
 
   constructor(
     options: Partial<BuildOptions>,
@@ -65,6 +66,9 @@ export class UltraBuilder extends Builder {
       ? this.makeRelative(this.options.browserEntrypoint)
       : undefined;
     this.serverEntrypoint = this.makeRelative(this.options.serverEntrypoint);
+    this.publicRoot = resolvedOptions.publicRoot
+      ? this.makeRelative(resolvedOptions.publicRoot)
+      : undefined;
 
     this.#initEntrypoints();
     this.#initExcluded();
@@ -86,6 +90,16 @@ export class UltraBuilder extends Builder {
      * Copy sources to output
      */
     const buildSources = await this.copySources(sources);
+
+    /**
+     * Gather and copy custom public source
+     */
+    if (this.publicRoot) {
+      const publicSources = await this.gatherSources(this.publicRoot);
+      await this.copySources(
+        publicSources,
+      );
+    }
 
     /**
      * Execute the build
@@ -243,8 +257,8 @@ export class UltraBuilder extends Builder {
   makeRelative(path: string) {
     return `./${
       relative(
-        this.context.root,
-        fromFileUrl(path),
+      this.context.root,
+      fromFileUrl(path),
       )
     }`;
   }

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -31,6 +31,7 @@ export async function createServer(
     resolvedOptions as Required<CreateServerOptions>;
 
   const root = Deno.cwd();
+  const publicRoot = resolvedOptions.public || root;
   const importMapPath = resolveImportMapPath(mode, root, options.importMapPath);
   const assetManifestPath =
     toFileUrl(resolve(root, "asset-manifest.json")).href;
@@ -62,7 +63,7 @@ export async function createServer(
     server.use(
       "*",
       serveStatic({
-        root: resolve(root, "./public"),
+        root: resolve(publicRoot, "./public"),
         cache: false,
       }),
     );
@@ -73,7 +74,7 @@ export async function createServer(
     server.use(
       "*",
       serveStatic({
-        root: resolve(root, "./public"),
+        root: resolve(publicRoot, "./public"),
         cache: true,
       }),
     );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,10 @@ export type Context<
 export type CreateServerOptions = {
   mode?: Mode;
   /**
+   * The path to the public folder.
+   */
+  public?: string;
+  /**
    * The path to your ImportMap. Ultra will inject this into the head
    * of your rendered HTML markup.
    */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,14 +13,14 @@ export type Context<
 export type CreateServerOptions = {
   mode?: Mode;
   /**
-   * The path to the public folder.
-   */
-  public?: string;
-  /**
    * The path to your ImportMap. Ultra will inject this into the head
    * of your rendered HTML markup.
    */
   importMapPath: string;
+  /**
+   * The path to the public folder.
+   */
+  publicRoot?: string;
   /**
    * The browser entrypoint. This is what initially gets sent with the server
    * rendered HTML markup. This should be what hydrates your React application.


### PR DESCRIPTION
For mono repo projects, sometimes the public folder is not located on the deno.cwd(). This allows us to pass a custom public root.