### PR TITLE
feat: useEnv hook

### DIFF
--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -1,7 +1,6 @@
 import useAsset from "ultra/hooks/use-asset.js";
 
 export default function App() {
-  console.log("Hello world!");
   return (
     <html lang="en">
       <head>

--- a/hooks/env-context.js
+++ b/hooks/env-context.js
@@ -4,9 +4,7 @@ import { createContext } from "react";
  * @type {React.Context<Map<string, string>>}
  */
 const EnvContext = createContext(
-  typeof window === "undefined"
-    ? new Map()
-    : new Map(Object.fromEntries(globalThis.__ULTRA_ENV)),
+  typeof Deno === "undefined" ? new Map(globalThis.__ULTRA_ENV) : new Map(),
 );
 
 export default EnvContext;

--- a/hooks/env-context.js
+++ b/hooks/env-context.js
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+
+/**
+ * @type {React.Context<Map<string, string>>}
+ */
+const EnvContext = createContext(
+  typeof window === "undefined"
+    ? new Map()
+    : new Map(Object.fromEntries(globalThis.__ULTRA_ENV)),
+);
+
+export default EnvContext;

--- a/hooks/use-env.js
+++ b/hooks/use-env.js
@@ -1,0 +1,15 @@
+import { useContext, useMemo } from "react";
+import EnvContext from "./env-context.js";
+
+/**
+ * @param {string} name
+ */
+export default function useEnv(name) {
+  if (
+    typeof Deno === "undefined" && name.startsWith("ULTRA_PUBLIC_") === false
+  ) {
+    throw new Error(`Attempt to access non-public env variable. ${name}`);
+  }
+  const context = useContext(EnvContext);
+  return useMemo(() => context.get(name), [name]);
+}

--- a/lib/context/env.ts
+++ b/lib/context/env.ts
@@ -1,0 +1,26 @@
+import { createElement as h } from "react";
+import EnvContext from "../../hooks/env-context.js";
+import useFlushEffects from "../../hooks/use-flush-effects.js";
+
+export function EnvProvider({ children }: { children: JSX.Element }) {
+  const env = Object.entries(Deno.env.toObject()).filter(([key]) =>
+    key.startsWith("ULTRA_PUBLIC_")
+  );
+
+  const value = new Map<string, string>(env);
+
+  useFlushEffects(() => {
+    return (
+      h("script", {
+        type: "text/javascript",
+        dangerouslySetInnerHTML: {
+          __html: `globalThis.__ULTRA_ENV = ${
+            JSON.stringify(Array.from(value.entries()))
+          }`,
+        },
+      })
+    );
+  });
+
+  return h(EnvContext.Provider, { value }, children);
+}

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -8,6 +8,7 @@ export {
   resolve,
   toFileUrl,
 } from "https://deno.land/std@0.153.0/path/mod.ts";
+export { config as dotenv } from "https://deno.land/std@0.153.0/dotenv/mod.ts";
 export { default as outdent } from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 export { gte } from "https://deno.land/std@0.153.0/semver/mod.ts";
 export { crayon } from "https://deno.land/x/crayon@3.3.2/mod.ts";

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from "react";
 import { createElement as h } from "react";
 import { AssetProvider } from "./context/asset.ts";
 import { DataStreamProvider } from "./context/dataStream.ts";
+import { EnvProvider } from "./context/env.ts";
 import { FlushEffectsProvider } from "./context/flushEffects.ts";
 import { IslandProvider } from "./context/island.ts";
 import { ServerContextProvider } from "./context/server.ts";
@@ -18,23 +19,26 @@ export function UltraProvider(
     UltraProviderProps
   >,
 ) {
-  return h(
-    ServerContextProvider,
-    {
-      context,
-      children: h(DataStreamProvider, {
-        children: h(
-          FlushEffectsProvider,
-          null,
-          h(AssetProvider, {
-            value: assetManifest,
-            children: h(IslandProvider, {
-              children,
-              baseUrl,
-            }),
-          }),
-        ),
-      }),
-    },
-  );
+  return h(ServerContextProvider, {
+    context,
+    children: h(DataStreamProvider, {
+      children: h(
+        FlushEffectsProvider,
+        {
+          children: h(
+            EnvProvider,
+            {
+              children: h(AssetProvider, {
+                value: assetManifest,
+                children: h(IslandProvider, {
+                  children,
+                  baseUrl,
+                }),
+              }),
+            },
+          ),
+        },
+      ),
+    }),
+  });
 }

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -1,11 +1,16 @@
 import { ULTRA_COMPILER_PATH } from "./constants.ts";
-import { assert, Hono, resolve, toFileUrl } from "./deps.ts";
+import { assert, dotenv, Hono, resolve, toFileUrl } from "./deps.ts";
 import { ensureMinDenoVersion } from "./dev/ensureMinDenoVersion.ts";
+import { log } from "./logger.ts";
 import { serveStatic } from "./middleware/serveStatic.ts";
 import { CreateServerOptions, Mode } from "./types.ts";
 import { UltraServer } from "./ultra.ts";
-import { log } from "./logger.ts";
 import { resolveImportMapPath } from "./utils/import-map.ts";
+
+/**
+ * Dotenv
+ */
+await dotenv({ export: true });
 
 /**
  * Check if we are running on Deno Deploy and set the mode to production


### PR DESCRIPTION
Allows using ULTRA_PUBLIC_ prefixed environment variables. Also adds support for `.env` files to be loaded from the project root

eg

```ts
const foo = useEnv('ULTRA_PUBLIC_FOO')
```