### PR TITLE
Extended useAsync functionality

### DIFF
--- a/hooks/use-async.js
+++ b/hooks/use-async.js
@@ -11,7 +11,7 @@ import DataStreamContext from "./data-stream-context.js";
  * @template T
  * @param {() => Promise<T>} callback A function that returns a promise. On the server, this function will be called and the result streamed to the client.
  * @param {Options} Options
- * @returns {(callback | Promise<T>)}
+ * @returns {callback}
  */
 
 export default function useAsync(
@@ -27,7 +27,10 @@ export default function useAsync(
     return callback;
   } else {
     try {
-      if (returnCallback) return callback;
+      if (returnCallback) {
+        return callback;
+      }
+
       const element = document.getElementById(key);
       // If the element doesn't exist, the data hasn't streamed in yet.
       // Let's wait for the data to stream in.

--- a/hooks/use-async.js
+++ b/hooks/use-async.js
@@ -2,12 +2,22 @@ import { useContext, useId } from "react";
 import DataStreamContext from "./data-stream-context.js";
 
 /**
- * @template T
- * @param {() => Promise<T>} callback
- * @param {boolean} [ssrOnly=true] - Whether to only use the server side resolved data or not
- * @returns {callback}
+ * @typedef {Object} Options
+ * @property {boolean} [false] returnCallback - Should the streamed data or callback be returned on the client.
+ * @property {number} [5000] streamTimeout - How long to wait for the stream to finish before returning a rejected promise.
  */
-export default function useAsync(callback, ssrOnly = true) {
+
+/**
+ * @template T
+ * @param {() => Promise<T>} callback - A function that returns a promise. On the server, this function will be called and the result streamed to the client.
+ * @param {Options} Options
+ * @returns {(callback | Promise<T>)}
+ */
+
+export default function useAsync(
+  callback,
+  { returnCallback = false, streamTimeout = 5000 } = {}
+) {
   const id = useId();
   const key = `ultra-async-data-stream-${id}`;
   const addDataStreamCallback = useContext(DataStreamContext);
@@ -17,17 +27,53 @@ export default function useAsync(callback, ssrOnly = true) {
     return callback;
   } else {
     try {
+      if (returnCallback) return callback;
       const element = document.getElementById(key);
-      if (element && ssrOnly) {
-        return function resolvedCallback() {
-          return JSON.parse(element.innerText);
+      // If the element doesn't exist, the data hasn't streamed in yet.
+      // Let's wait for the data to stream in.
+      if (!element) {
+        return function awaitStream() {
+          return new Promise((resolve, reject) => {
+            let timeout;
+            function mutationCallback(_list, observer) {
+              const element = document.getElementById(key);
+              if (element) {
+                clearTimeout(timeout);
+                observer.disconnect();
+                resolve(JSON.parse(element.innerText));
+              }
+            }
+            const mutationObserver = new MutationObserver(mutationCallback);
+            mutationObserver.observe(document.body, {
+              childList: true,
+              subtree: true,
+            });
+            // If the data hasn't streamed in after the timeout, we'll reject the promise.
+            // If streamTimeout === 0, the promise never rejects.
+            if (streamTimeout !== 0) {
+              timeout = setTimeout(() => {
+                mutationObserver.disconnect();
+                reject();
+              }, streamTimeout);
+            }
+          });
         };
+        // We have data, lets return it.
       } else {
-        return callback;
+        return function resolvedCallback() {
+          return Promise.resolve(JSON.parse(element.innerText));
+        };
       }
     } catch (error) {
       console.error(error);
-      return callback;
+      // Lets return the callback if we can
+      if (returnCallback) {
+        return callback;
+      }
+      // Or else just return a function to return a rejected promise.
+      return function reject() {
+        return Promise.reject(error);
+      };
     }
   }
 }

--- a/hooks/use-async.js
+++ b/hooks/use-async.js
@@ -3,20 +3,20 @@ import DataStreamContext from "./data-stream-context.js";
 
 /**
  * @typedef {Object} Options
- * @property {boolean} [false] returnCallback - Should the streamed data or callback be returned on the client.
- * @property {number} [5000] streamTimeout - How long to wait for the stream to finish before returning a rejected promise.
+ * @property {boolean} [returnCallback=false] Should the streamed data or callback be returned on the client.
+ * @property {number} [streamTimeout=5000] How long to wait for the stream to finish before returning a rejected promise.
  */
 
 /**
  * @template T
- * @param {() => Promise<T>} callback - A function that returns a promise. On the server, this function will be called and the result streamed to the client.
+ * @param {() => Promise<T>} callback A function that returns a promise. On the server, this function will be called and the result streamed to the client.
  * @param {Options} Options
  * @returns {(callback | Promise<T>)}
  */
 
 export default function useAsync(
   callback,
-  { returnCallback = false, streamTimeout = 5000 } = {}
+  { returnCallback = false, streamTimeout = 5000 } = {},
 ) {
   const id = useId();
   const key = `ultra-async-data-stream-${id}`;
@@ -70,7 +70,7 @@ export default function useAsync(
       if (returnCallback) {
         return callback;
       }
-      // Or else just return a function to return a rejected promise.
+      // Or else just return a function that rejects with the error.
       return function reject() {
         return Promise.reject(error);
       };

--- a/hooks/use-mounted-state.js
+++ b/hooks/use-mounted-state.js
@@ -1,0 +1,19 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * @returns {() => boolean}
+ */
+export default function useMountedState() {
+  const mountedRef = useRef(false);
+  const get = useCallback(() => mountedRef.current, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  return get;
+}

--- a/test/hooks/use-async.test.tsx
+++ b/test/hooks/use-async.test.tsx
@@ -3,8 +3,11 @@ import { renderToStream } from "../../lib/render.ts";
 import useAsync from "../../hooks/use-async.js";
 
 Deno.test("useAsync hook", async () => {
+  // deno-lint-ignore no-explicit-any
+  let callback: () => Promise<any>;
+
   const App = () => {
-    useAsync(() =>
+    callback = useAsync(() =>
       fetch(
         "https://jsonplaceholder.typicode.com/todos/1",
       ).then((response) => response.json())
@@ -33,6 +36,14 @@ Deno.test("useAsync hook", async () => {
 
   const response = new Response(stream);
   const text = await response.text();
+  const data = await callback!();
+
+  assertEquals(data, {
+    userId: 1,
+    id: 1,
+    title: "delectus aut autem",
+    completed: false,
+  });
 
   assertEquals(
     text.includes(


### PR DESCRIPTION
The current implementation of `useAsync` returns the callback if data is not present when the component mounts, which means if the data on the server doesn't resolve and stream practically instantly, the client will return the callback - which means fetching client side. The data that gets streamed in is ignored. The idea here is that we want to start fetching on the server, and access it on the client. 

I think one approach is to have this hook always return a function that returns a promise. This makes it nicely compatible with fetching libraries and I think it's a decent API. So we can either return a promise to return the data when it streams in, or if we already have the data we can choose to either return it or return the callback.

This way, an end user can do something like this:

```
const mounted = useMount(false)
// ...
useAsync(() => fetch('/api/data'), { returnCallback: mounted })
```

So if the data is already present, it will use it, but subsequent calls will return the callback for refetching. And if the data isn't present, it will return a promise to return the data from the stream when it arrives, and subsequent calls will return the callback for refetching. And if `returnCallback` is always false, it will always return the streamed data without making more requests.

If it's possible, it would be nice to have the hook figure out if data is being streamed - if not, it would make sense to return the callback at that point. Although that can be handled by the client by means of some global `isMounted` state (eg. `globalThis.ultra.mounted = true`) for handling cases like client-side routing.

Let me know what you think of this idea.

(oh, also I have no idea what I'm doing with jsdoc pls help)