### PR TITLE
deps: updated Hono to latest version

### DIFF
--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -21,7 +21,7 @@ export { StringReader } from "https://deno.land/std@0.159.0/io/readers.ts";
 
 export { wait } from "https://deno.land/x/wait@0.1.12/mod.ts";
 
-export { Hono } from "https://deno.land/x/hono@v2.1.4/mod.ts";
-export { getFilePath } from "https://deno.land/x/hono@v2.1.4/utils/filepath.ts";
-export { getMimeType } from "https://deno.land/x/hono@v2.1.4/utils/mime.ts";
-export { logger } from "https://deno.land/x/hono@v2.1.4/middleware.ts";
+export { Hono } from "https://deno.land/x/hono@v2.2.5/mod.ts";
+export { getFilePath } from "https://deno.land/x/hono@v2.2.5/utils/filepath.ts";
+export { getMimeType } from "https://deno.land/x/hono@v2.2.5/utils/mime.ts";
+export { logger } from "https://deno.land/x/hono@v2.2.5/middleware.ts";

--- a/lib/middleware/compiler.ts
+++ b/lib/middleware/compiler.ts
@@ -68,7 +68,7 @@ export const compiler = (options: CompilerOptions) => {
           },
         });
       } catch (error) {
-        console.error(error);
+        log.error(error);
       }
     }
 

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -57,41 +57,30 @@ export async function createServer(
 
   await server.init();
 
-  /**
-   * We always try to serve public assets before
-   * anything else.
-   */
-  server.use(
-    "*",
-    serveStatic({
-      root: resolve(root, "./public"),
-      cache: mode !== "development",
-    }),
-  );
+  // We always try to serve public assets before anything else.
+  // deno-fmt-ignore
+  server.get("*", serveStatic({
+    root: resolve(root, "./public"),
+    cache: mode !== "development",
+  }));
 
-  /**
-   * Serve anything else static at "/"
-   */
-  server.use(
-    "*",
-    serveStatic({
-      root: resolve(root, "./"),
-      cache: mode !== "development",
-    }),
-  );
+  // Serve anything else static at "/"
+  // deno-fmt-ignore
+  server.get("*", serveStatic({
+    root: resolve(root, "./"),
+    cache: mode !== "development",
+  }));
 
   if (mode === "development") {
     log.info("Loading compiler");
     const { compiler } = await import("./middleware/compiler.ts");
 
-    server.use(
-      `${ULTRA_COMPILER_PATH}/*`,
-      compiler({
-        mode,
-        root,
-        ...options.compilerOptions,
-      }),
-    );
+    // deno-fmt-ignore
+    server.get(`${ULTRA_COMPILER_PATH}/*`, compiler({
+      mode,
+      root,
+      ...options.compilerOptions,
+    }));
   }
 
   return server;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,8 +1,8 @@
-import type { Environment } from "https://deno.land/x/hono@v2.1.4/hono.ts";
-import type { Context as HonoContext } from "https://deno.land/x/hono@v2.1.4/mod.ts";
-export type { StatusCode } from "https://deno.land/x/hono@v2.1.4/utils/http-status.ts";
+import type { Environment } from "https://deno.land/x/hono@v2.2.5/hono.ts";
+import type { Context as HonoContext } from "https://deno.land/x/hono@v2.2.5/mod.ts";
+export type { StatusCode } from "https://deno.land/x/hono@v2.2.5/utils/http-status.ts";
 import type { JscTarget } from "https://esm.sh/@swc/core@1.3.0/types.d.ts";
-export type { Next } from "https://deno.land/x/hono@v2.1.4/mod.ts";
+export type { Next } from "https://deno.land/x/hono@v2.2.5/mod.ts";
 
 export type Mode = "development" | "production";
 


### PR DESCRIPTION
This PR updates Hono to the latest version 2.2.5 also changes our static routes to only use GET