### PR TITLE
fix: match the actual head closing tag when inserting

### DIFF
--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -130,7 +130,7 @@ export function createHeadInsertionTransformStream(
         freezing = true;
       } else {
         const content = decodeText(chunk);
-        const index = content.indexOf("</head");
+        const index = content.indexOf("</head>");
         if (index !== -1) {
           const insertedHeadContent = content.slice(0, index) + insertion +
             content.slice(index);


### PR DESCRIPTION
Our matching logic for the closing head tag follows Next.JS.

They just commited a fix which would prevent matching something like `</header>`

So this PR replicates that