### PR TITLE
fix: client entry point absolute path

### DIFF
--- a/lib/ultra.ts
+++ b/lib/ultra.ts
@@ -152,7 +152,7 @@ export class UltraServer extends Hono {
     if (this.mode === "production") {
       for (const [specifier, resolved] of Object.entries(importMap.imports)) {
         if (specifier === entrypointSpecifier) {
-          entrypointSpecifier = resolved;
+          entrypointSpecifier = resolved.replace("./", "/");
         }
       }
     } else {


### PR DESCRIPTION
In production, client scripts are relative to current depth, meaning they will 404 in deeply nested paths.

This should always make them absolute paths.