### PR TITLE
fix: updated mesozoic to allow bypassing the vendoring of remote dependencies

### DIFF
--- a/lib/build/deps.ts
+++ b/lib/build/deps.ts
@@ -3,13 +3,13 @@ export {
   ContextBuilder,
   FileBag,
   VirtualFile,
-} from "https://deno.land/x/mesozoic@v1.0.5/mod.ts";
+} from "https://deno.land/x/mesozoic@v1.1.0/mod.ts";
 export type {
   BuilderOptions,
   BuildResult,
   PatternLike,
-} from "https://deno.land/x/mesozoic@v1.0.5/mod.ts";
-export type { EntrypointConfig } from "https://deno.land/x/mesozoic@v1.0.5/lib/entrypoint.ts";
+} from "https://deno.land/x/mesozoic@v1.1.0/mod.ts";
+export type { EntrypointConfig } from "https://deno.land/x/mesozoic@v1.1.0/lib/entrypoint.ts";
 export { deepMerge } from "https://deno.land/std@0.159.0/collections/deep_merge.ts";
 export { crayon } from "https://deno.land/x/crayon@3.3.2/mod.ts";
 export {

--- a/lib/build/types.ts
+++ b/lib/build/types.ts
@@ -24,6 +24,16 @@ export type BuildOptions = {
    */
   output?: string;
   /**
+   * A relative path of the output directory to place vendored remote dependencies.
+   * @default "vendor"
+   */
+  vendorPath: string;
+  /**
+   * A flag to enable or disable vendoring remote dependencies.
+   * @default true
+   */
+  vendorDependencies: boolean;
+  /**
    * The relative path to your importMap
    * @default "./importMap.json"
    */

--- a/lib/build/ultra.ts
+++ b/lib/build/ultra.ts
@@ -29,6 +29,8 @@ type DefaultBuildOptions = Omit<
 const defaultOptions: DefaultBuildOptions = {
   root: Deno.cwd(),
   output: ".ultra",
+  vendorPath: "vendor",
+  vendorDependencies: true,
   importMapPath: "./importMap.json",
   ignored: [".git", join("**", ".DS_Store")],
 };
@@ -67,6 +69,8 @@ export class UltraBuilder extends Builder {
     const context = new ContextBuilder()
       .setRoot(root)
       .setOutput(output)
+      .setVendorPath(resolvedOptions.vendorPath)
+      .setVendorDependencies(resolvedOptions.vendorDependencies)
       .setImportMapPath(resolvedOptions.importMapPath)
       .ignore(makeRelative(root, Deno.mainModule))
       .ignore(options.ignored || [])

--- a/test/fixture/build.test.ts
+++ b/test/fixture/build.test.ts
@@ -25,6 +25,28 @@ Deno.test(
 );
 
 Deno.test(
+  "it works with vendorDependencies false",
+  { ignore: TEST_FIXTURES },
+  async () => {
+    const builder = createBuilder({
+      browserEntrypoint: import.meta.resolve("./client.tsx"),
+      serverEntrypoint: import.meta.resolve("./server.tsx"),
+      vendorDependencies: false,
+    });
+
+    builder.ignore([
+      "./README.md",
+      "./importMap.json",
+      "./*.test.*",
+    ]);
+
+    const result = await builder.build();
+
+    assertEquals(result.outputSources.size > 0, true);
+  },
+);
+
+Deno.test(
   "it works without a browser entrypoint",
   { ignore: TEST_FIXTURES },
   async () => {


### PR DESCRIPTION
This PR fixes #193

Mesozoic was updated to allow this feature as well as some options added to `createBuilder`.