### PR TITLE
chore: update mesozoic

### DIFF
--- a/lib/build/deps.ts
+++ b/lib/build/deps.ts
@@ -3,13 +3,13 @@ export {
   ContextBuilder,
   FileBag,
   VirtualFile,
-} from "https://deno.land/x/mesozoic@v1.1.3/mod.ts";
+} from "https://deno.land/x/mesozoic@v1.2.0/mod.ts";
 export type {
   BuilderOptions,
   BuildResult,
   PatternLike,
-} from "https://deno.land/x/mesozoic@v1.1.3/mod.ts";
-export type { EntrypointConfig } from "https://deno.land/x/mesozoic@v1.1.3/lib/entrypoint.ts";
+} from "https://deno.land/x/mesozoic@v1.2.0/mod.ts";
+export type { EntrypointConfig } from "https://deno.land/x/mesozoic@v1.2.0/lib/entrypoint.ts";
 export { deepMerge } from "https://deno.land/std@0.164.0/collections/deep_merge.ts";
 export { crayon } from "https://deno.land/x/crayon@3.3.2/mod.ts";
 export {


### PR DESCRIPTION
Updates mesozoic to address an issue with the browser importMap resolved paths being relative.

Should also help issues with Netlify deployment