### PR TITLE
fix: The `ignored` option is not working

### DIFF
--- a/lib/build/deps.ts
+++ b/lib/build/deps.ts
@@ -3,13 +3,13 @@ export {
   ContextBuilder,
   FileBag,
   VirtualFile,
-} from "https://deno.land/x/mesozoic@v1.2.1/mod.ts";
+} from "https://deno.land/x/mesozoic@v1.2.3/mod.ts";
 export type {
   BuilderOptions,
   BuildResult,
   PatternLike,
-} from "https://deno.land/x/mesozoic@v1.2.1/mod.ts";
-export type { EntrypointConfig } from "https://deno.land/x/mesozoic@v1.2.1/lib/entrypoint.ts";
+} from "https://deno.land/x/mesozoic@v1.2.3/mod.ts";
+export type { EntrypointConfig } from "https://deno.land/x/mesozoic@v1.2.3/lib/entrypoint.ts";
 export { deepMerge } from "https://deno.land/std@0.164.0/collections/deep_merge.ts";
 export { crayon } from "https://deno.land/x/crayon@3.3.2/mod.ts";
 export {

--- a/test/fixture/build.test.ts
+++ b/test/fixture/build.test.ts
@@ -14,14 +14,18 @@ Deno.test(
     });
 
     builder.ignore([
-      "./output/**",
+      "./output/",
       "./README.md",
       "./importMap.json",
       "./*.test.*",
     ]);
 
     const result = await builder.build();
+    const ignoredOutput = result.outputSources.filter((source) =>
+      source.relativePath().startsWith("./output/")
+    );
 
+    assertEquals(ignoredOutput.size, 0);
     assertEquals(result.outputSources.size > 0, true);
     assertEquals(result.dynamicImports.size, 2);
 
@@ -46,7 +50,7 @@ Deno.test(
     });
 
     builder.ignore([
-      "./output/**",
+      "./output/",
       "./README.md",
       "./importMap.json",
       "./*.test.*",
@@ -80,7 +84,7 @@ Deno.test(
     });
 
     builder.ignore([
-      "./output/**",
+      "./output/",
       "./README.md",
       "./importMap.json",
       "./*.test.*",
@@ -114,7 +118,7 @@ Deno.test(
     });
 
     builder.ignore([
-      "./output/**",
+      "./output/",
       "./README.md",
       "./importMap.json",
       "./*.test.*",


### PR DESCRIPTION
Fixes #221

Updated mesozoic to include a fix that when an 'ignore' pattern ends with '/' it assumes that you want to deeply ignore anything that matches that pattern.

So it essentially is doing the same as the below:

```ts
builder.ignore('./directory/**')
```