### PR TITLE
Specified version of wouter

### DIFF
--- a/lib/create/common/content/importMap.ts
+++ b/lib/create/common/content/importMap.ts
@@ -41,7 +41,9 @@ export function importMapContent(config: Config) {
     )
   }
 
-            ${p.wouter('"wouter": "https://esm.sh/wouter@2.9.2?external=react",')}
+            ${
+    p.wouter('"wouter": "https://esm.sh/wouter@2.9.2?external=react",')
+  }
             ${
     p.wouter(
       '"wouter/static-location": "https://esm.sh/wouter@2.9.2/static-location?external=react",',

--- a/lib/create/common/content/importMap.ts
+++ b/lib/create/common/content/importMap.ts
@@ -41,10 +41,10 @@ export function importMapContent(config: Config) {
     )
   }
 
-            ${p.wouter('"wouter": "https://esm.sh/wouter?external=react",')}
+            ${p.wouter('"wouter": "https://esm.sh/wouter@2.9.2?external=react",')}
             ${
     p.wouter(
-      '"wouter/static-location": "https://esm.sh/wouter/static-location?external=react",',
+      '"wouter/static-location": "https://esm.sh/wouter@2.9.2/static-location?external=react",',
     )
   }
 


### PR DESCRIPTION
Some editors complain that the import redirects to a specific version, so specifying it, eliminates the problem.