### PR TITLE
Remove Deno.run in favor of new Deno.Command

### DIFF
--- a/examples/ultra-website/dev.ts
+++ b/examples/ultra-website/dev.ts
@@ -5,14 +5,14 @@ await compile("./content");
 /**
  * Now start the server
  */
-const server = Deno.run({
-  cmd: [
-    Deno.execPath(),
+const command = new Deno.Command(Deno.execPath(), {
+  args: [
     "run",
     "-A",
     "--location=http://localhost:8000",
     "./server.tsx",
   ],
 });
+const server = command.spawn();
 
-await server.status();
+await server.status;

--- a/examples/ultra-website/public/service-worker.js
+++ b/examples/ultra-website/public/service-worker.js
@@ -7,7 +7,7 @@ self.addEventListener("install", (event) => {
     (async function () {
       const cache = await caches.open(CACHE_NAME);
       await cache.addAll(CACHED_URLS);
-    })()
+    })(),
   );
 });
 
@@ -65,8 +65,8 @@ self.addEventListener("activate", (event) => {
             const deleteThisCache = cacheName !== CACHE_NAME;
             return deleteThisCache;
           })
-          .map((cacheName) => caches.delete(cacheName))
+          .map((cacheName) => caches.delete(cacheName)),
       );
-    })()
+    })(),
   );
 });

--- a/examples/with-mdx/dev.ts
+++ b/examples/with-mdx/dev.ts
@@ -5,8 +5,14 @@ await compile("./content");
 /**
  * Now start the server
  */
-const server = Deno.run({
-  cmd: [Deno.execPath(), "run", "-A", "./server.tsx"],
+const command = new Deno.Command(Deno.execPath(), {
+  args: [
+    "run",
+    "-A",
+    "./server.tsx",
+  ],
 });
 
-await server.status();
+const server = command.spawn();
+
+await server.status;

--- a/examples/with-unocss/dev.ts
+++ b/examples/with-unocss/dev.ts
@@ -8,15 +8,16 @@ async function dev() {
     patterns: ["src/**/*"],
     outFile: "public/uno.css",
   });
-  const server = Deno.run({
-    cmd: [
-      Deno.execPath(),
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
       "run",
       "-A",
       "--location=http://localhost:8000",
       "./server.tsx",
     ],
   });
+  const server = command.spawn();
+
   return server;
 }
 

--- a/lib/create/common/createUltraApp.ts
+++ b/lib/create/common/createUltraApp.ts
@@ -92,7 +92,15 @@ export async function createUltraApp(config: Config) {
   }
 
   // Format files
-  await Deno.run({ cmd: ["deno", "fmt", `${config.name}/`] }).status();
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "deno",
+      "fmt",
+      `${config.name}/`,
+    ],
+  });
+
+  await command.spawn().status;
 
   // Finish up
   console.log(outdent`

--- a/test/fixture/build.test.ts
+++ b/test/fixture/build.test.ts
@@ -30,14 +30,18 @@ Deno.test(
     assertEquals(result.dynamicImports.size, 2);
 
     // Test that the built output starts correctly
-    const process = await Deno.run({
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "task",
+        "start",
+      ],
       cwd: "./output/browser-entrypoint",
-      cmd: [Deno.execPath(), "task", "start"],
     });
+    const process = command.spawn();
 
-    const status = await process.status();
+    const status = await process.status;
     assert(status.success);
-    await process.close();
+    await process.kill();
   },
 );
 
@@ -62,14 +66,18 @@ Deno.test(
     assertEquals(result.dynamicImports.size, 2);
 
     // Test that the built output starts correctly
-    const process = await Deno.run({
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "task",
+        "start:no-browser",
+      ],
       cwd: "./output/no-browser-entrypoint",
-      cmd: [Deno.execPath(), "task", "start:no-browser"],
     });
+    const process = command.spawn();
 
-    const status = await process.status();
+    const status = await process.status;
     assert(status.success);
-    await process.close();
+    await process.kill();
   },
 );
 
@@ -96,14 +104,18 @@ Deno.test(
     assertEquals(result.dynamicImports.size, 2);
 
     // Test that the built output starts correctly
-    const process = await Deno.run({
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "task",
+        "start",
+      ],
       cwd: "./output/no-vendor-deps",
-      cmd: [Deno.execPath(), "task", "start"],
     });
+    const process = command.spawn();
 
-    const status = await process.status();
+    const status = await process.status;
     assert(status.success);
-    await process.close();
+    await process.kill();
   },
 );
 
@@ -130,13 +142,17 @@ Deno.test(
     assertEquals(result.dynamicImports.size, 2);
 
     // Test that the built output starts correctly
-    const process = await Deno.run({
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "task",
+        "start",
+      ],
       cwd: "./output/inline-dynamic-imports",
-      cmd: [Deno.execPath(), "task", "start"],
     });
+    const process = command.spawn();
 
-    const status = await process.status();
+    const status = await process.status;
     assert(status.success);
-    await process.close();
+    await process.kill();
   },
 );

--- a/tools/dev.ts
+++ b/tools/dev.ts
@@ -91,9 +91,9 @@ async function dev() {
     /**
      * Run the server with generated dev config
      */
-    const process = Deno.run({
-      cmd: [
-        Deno.execPath(),
+
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
         "run",
         "-A",
         "--watch",
@@ -106,8 +106,9 @@ async function dev() {
         ULTRA_MODE: "development",
       },
     });
+    const process = command.spawn();
 
-    await process.status();
+    await process.status;
   } catch (error) {
     console.error(error);
     Deno.exit(1);

--- a/tools/test-examples.ts
+++ b/tools/test-examples.ts
@@ -5,23 +5,23 @@ async function testExample(example: string) {
   try {
     const examplePath = join("examples", example);
     await initExampleConfig(example);
-    const cmd = [
-      Deno.execPath(),
-      "test",
-      "-c",
-      "deno.dev.json",
-      "-A",
-    ];
-    console.log("test ", examplePath, cmd);
-    const process = Deno.run({
-      cmd,
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "test",
+        "-c",
+        "deno.dev.json",
+        "-A",
+      ],
       cwd: examplePath,
       env: {
         ULTRA_MODE: "development",
       },
     });
+    const process = command.spawn();
 
-    const status = await process.status();
+    console.log("test ", examplePath);
+
+    const status = await process.status;
     if (status.code > 0) {
       Deno.exit(status.code);
     }


### PR DESCRIPTION
Deno.run is deprecated for https://deno.land/api@v1.33.4?s=Deno.Command