### PR TITLE
fix: support compiling remote sources in dev

### DIFF
--- a/importMap.dev.json
+++ b/importMap.dev.json
@@ -31,6 +31,7 @@
     "@mui/material/colors": "https://esm.sh/v122/@mui/material@5.10.3/colors",
     "@stitches/react": "https://esm.sh/v122/@stitches/react@1.2.8?external=react",
     "react-helmet-async": "https://esm.sh/v122/react-helmet-async@1.3.0?external=react",
+    "@ultra/qrcode/": "https://deno.land/x/qrcode@v2.0.0/",
     "ultra/": "./"
   }
 }

--- a/lib/middleware/compiler.ts
+++ b/lib/middleware/compiler.ts
@@ -14,12 +14,17 @@ export const compiler = (options: CompilerOptions) => {
 
   return async (context: Context, next: Next) => {
     const method = context.req.method;
-    const requestPathname = new URL(context.req.url).pathname;
+    const requestPathname = decodeURIComponent(
+      new URL(context.req.url).pathname,
+    );
+
     const pathname = requestPathname.replace(`${ULTRA_COMPILER_PATH}/`, "");
+    const isRemoteSource = pathname.startsWith("https://") ||
+      pathname.startsWith("http://");
 
     const extension = extname(pathname);
-    const path = join(root, pathname);
-    const url = toFileUrl(path);
+    const path = !isRemoteSource ? join(root, pathname) : pathname;
+    const url = !isRemoteSource ? toFileUrl(path) : new URL(pathname);
 
     const isCompilerTarget = [".ts", ".tsx", ".js", ".jsx"].includes(extension);
 

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -3,7 +3,7 @@ import * as ReactDOMServer from "react-dom/server";
 import { UltraProvider } from "./provider.ts";
 import { getServerInsertedHTML } from "./context/serverInsertedHtml.ts";
 import { createFlushDataStreamHandler } from "./context/dataStream.ts";
-import type { Context } from "./types.ts";
+import type { Context, Mode } from "./types.ts";
 import { log } from "./logger.ts";
 import {
   continueFromInitialStream,
@@ -13,6 +13,7 @@ import {
 import { ImportMap } from "./types.ts";
 
 type RenderToStreamOptions = ReactDOMServer.RenderToReadableStreamOptions & {
+  mode?: Mode;
   baseUrl: string;
   importMap: ImportMap | undefined;
   assetManifest: Map<string, string> | undefined;
@@ -43,6 +44,7 @@ export async function renderToStream(
   options: RenderToStreamOptions,
 ) {
   const {
+    mode,
     baseUrl,
     generateStaticHTML = false,
     disableHydration = false,
@@ -80,6 +82,7 @@ export async function renderToStream(
   );
 
   return await continueFromInitialStream(renderStream, {
+    mode,
     generateStaticHTML,
     disableHydration,
     getServerInsertedHTML,

--- a/lib/ultra.ts
+++ b/lib/ultra.ts
@@ -122,6 +122,7 @@ export class UltraServer extends Hono {
     log.debug("Rendering component");
 
     return renderToStream(Component, context, {
+      mode: this.mode,
       baseUrl: this.baseUrl,
       assetManifest: this.assetManifest,
       importMap: this.importMap,

--- a/test/fixture/importMap.json
+++ b/test/fixture/importMap.json
@@ -14,6 +14,7 @@
     "zod": "https://deno.land/x/zod@v3.19.1/mod.ts",
     "twind": "https://esm.sh/twind@0.16.17",
     "twind/sheets": "https://esm.sh/twind@0.16.17/sheets",
-    "ultra/": "https://denopkg.com/exhibitionist-digital/ultra@main/"
+    "ultra/": "https://denopkg.com/exhibitionist-digital/ultra@main/",
+    "@ultra/qrcode/": "https://deno.land/x/qrcode@v2.0.0/"
   }
 }


### PR DESCRIPTION
Prefixing an importSpecifier with `@ultra/` in your importMap will now allow importing remote files that would usually require transpiling for the browser.

eg.

```jsonc
{
  "imports": {
    // Your other imports
    "@ultra/qrcode/": "https://deno.land/x/qrcode@v2.0.0/"
  }
}
```

When the importMap is injected in the HTML stream sent to the browser during dev mode, the import `https://deno.land/x/qrcode@v2.0.0/` will be rewritten to `/_ultra/compiler/https%3A%2F%2Fdeno.land%2Fx%2Fqrcode%40v2.0.0%2F/`

The compiler middleware will then fetch that remote file and transpile as if it was a local file!