### PR TITLE
feat: support more import specifiers in dev

### DIFF
--- a/examples/basic/deno.json
+++ b/examples/basic/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A --no-check --watch ./server.tsx",
+    "dev": "ULTRA_MODE=development deno run -A --no-check --watch ./server.tsx",
     "test": "deno test --allow-all",
     "build": "deno run -A ./build.ts",
     "start": "ULTRA_MODE=production deno run -A --no-remote ./server.js"

--- a/examples/basic/importMap.json
+++ b/examples/basic/importMap.json
@@ -6,6 +6,7 @@
     "react-dom/server": "https://esm.sh/v122/react-dom@18.2.0/server?dev",
     "react-dom/client": "https://esm.sh/v122/react-dom@18.2.0/client?dev",
     "ultra/": "https://deno.land/x/ultra@v2.2.4/",
-    "@ultra/qrcode/": "https://deno.land/x/qrcode@v2.0.0/"
+    "@ultra/qrcode/": "https://deno.land/x/qrcode@v2.0.0/",
+    "@/": "./src/"
   }
 }

--- a/examples/basic/server.tsx
+++ b/examples/basic/server.tsx
@@ -3,9 +3,7 @@ import { createServer } from "ultra/server.ts";
 import App from "./src/app.tsx";
 
 const server = await createServer({
-  importMapPath: Deno.env.get("ULTRA_MODE") === "development"
-    ? import.meta.resolve("./importMap.dev.json")
-    : import.meta.resolve("./importMap.json"),
+  importMapPath: import.meta.resolve("./importMap.json"),
   browserEntrypoint: import.meta.resolve("./client.tsx"),
 });
 

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -1,5 +1,6 @@
 import useAsset from "ultra/hooks/use-asset.js";
 import useEnv from "ultra/hooks/use-env.js";
+import Button from "@/components/Button.tsx";
 
 export default function App() {
   // Read our environment variable from '.env' or the host environment
@@ -37,6 +38,7 @@ export default function App() {
             customise your routing, data fetching, and styling with popular
             libraries.
           </p>
+          <Button>Button</Button>
         </main>
       </body>
     </html>

--- a/examples/basic/src/components/Button.tsx
+++ b/examples/basic/src/components/Button.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+type ButtonProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
+
+export default function Button(props: ButtonProps) {
+  return <button className="btn" {...props} />;
+}

--- a/lib/middleware/compiler.ts
+++ b/lib/middleware/compiler.ts
@@ -3,6 +3,7 @@ import { ULTRA_COMPILER_PATH } from "../constants.ts";
 import { extname, join, sprintf, toFileUrl } from "../deps.ts";
 import { log } from "../logger.ts";
 import type { CompilerOptions, Context, Next } from "../types.ts";
+import { isCompilerTarget } from "../utils/compiler.ts";
 
 const { transform } = await createCompiler();
 
@@ -26,9 +27,9 @@ export const compiler = (options: CompilerOptions) => {
     const path = !isRemoteSource ? join(root, pathname) : pathname;
     const url = !isRemoteSource ? toFileUrl(path) : new URL(pathname);
 
-    const isCompilerTarget = [".ts", ".tsx", ".js", ".jsx"].includes(extension);
+    const shouldCompile = isCompilerTarget(pathname);
 
-    if (method === "GET" && isCompilerTarget) {
+    if (method === "GET" && shouldCompile) {
       const bytes = await fetch(url).then((response) => response.arrayBuffer());
       let source = new TextDecoder().decode(bytes);
 

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -160,13 +160,17 @@ export function createImportMapInjectionStream(
   log.debug("Stream inject importMap");
   let injected = false;
 
+  function isSpecialPrefix(specifier: string) {
+    return specifier.startsWith("@ultra/") || specifier.startsWith("@/");
+  }
+
   return createHeadInsertionTransformStream(() => {
     if (injected) return Promise.resolve("");
 
     if (mode === "development") {
       importMap.imports = Object.fromEntries(
         Object.entries(importMap.imports).map(([key, value]) => {
-          if (key.startsWith("@ultra/")) {
+          if (isSpecialPrefix(key)) {
             value = value.endsWith("/") ? value.slice(0, -1) : value;
             value = `/_ultra/compiler/${encodeURIComponent(value)}/`;
           }

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -6,10 +6,11 @@
  */
 import type { ReactElement } from "react";
 import * as ReactDOMServer from "react-dom/server";
-import { ImportMap, Mode, RenderedReadableStream } from "./types.ts";
-import { nonNullable } from "./utils/non-nullable.ts";
-import { log } from "./logger.ts";
 import { readableStreamFromReader, StringReader } from "./deps.ts";
+import { log } from "./logger.ts";
+import { ImportMap, Mode, RenderedReadableStream } from "./types.ts";
+import { isCompilerTarget } from "./utils/compiler.ts";
+import { nonNullable } from "./utils/non-nullable.ts";
 
 export function encodeText(input: string) {
   return new TextEncoder().encode(input);
@@ -170,7 +171,7 @@ export function createImportMapInjectionStream(
     if (mode === "development") {
       importMap.imports = Object.fromEntries(
         Object.entries(importMap.imports).map(([key, value]) => {
-          if (isSpecialPrefix(key)) {
+          if (isSpecialPrefix(key) || isCompilerTarget(value)) {
             value = value.endsWith("/") ? value.slice(0, -1) : value;
             value = `/_ultra/compiler/${encodeURIComponent(value)}/`;
           }

--- a/lib/utils/compiler.ts
+++ b/lib/utils/compiler.ts
@@ -1,0 +1,6 @@
+import { extname } from "../deps.ts";
+
+export function isCompilerTarget(path: string) {
+  const extension = extname(path);
+  return [".ts", ".tsx", ".js", ".jsx"].includes(extension);
+}


### PR DESCRIPTION
This PR add support for the following in importMaps

```json
{
    "imports": {
        "@/": "./src/",
        "base64": "https://deno.land/std@0.192.0/encoding/base64.ts"
    }
}
```
