### PR TITLE
fix: env doesn't include ULTRA_MODE

### DIFF
--- a/lib/context/env.ts
+++ b/lib/context/env.ts
@@ -3,11 +3,11 @@ import EnvContext from "../../hooks/env-context.js";
 import useServerInsertedHTML from "../../hooks/use-server-inserted-html.js";
 
 export function EnvProvider({ children }: { children: JSX.Element }) {
-  const env = Object.entries(Deno.env.toObject()).filter(([key]) =>
-    key.startsWith("ULTRA_PUBLIC_")
+  const publicEnv = Object.entries(Deno.env.toObject()).filter(([key]) =>
+    key.startsWith("ULTRA_PUBLIC_") || key === "ULTRA_MODE"
   );
 
-  const value = new Map<string, string>(env);
+  const value = new Map<string, string>(publicEnv);
 
   useServerInsertedHTML(() => {
     const entries = Array.from(value.entries());

--- a/lib/context/serverInsertedHtml.ts
+++ b/lib/context/serverInsertedHtml.ts
@@ -26,7 +26,9 @@ export const getServerInsertedHTML = (): Promise<string> => {
     h(
       Fragment,
       null,
-      Array.from(serverInsertedHTMLCallbacks).map((callback) => callback()),
+      Array.from(serverInsertedHTMLCallbacks).map((callback, index) =>
+        h(Fragment, { key: `server-insert-cb-${index}` }, callback())
+      ),
     ),
   ));
 };

--- a/test/unit/use-env.test.tsx
+++ b/test/unit/use-env.test.tsx
@@ -1,0 +1,46 @@
+import { assertEquals } from "https://deno.land/std@0.176.0/testing/asserts.ts";
+import useEnv from "../../hooks/use-env.js";
+import { renderToStream } from "../../lib/render.ts";
+
+Deno.test("useEnv hook", async () => {
+  let value;
+
+  Deno.env.set("ULTRA_MODE", "foo");
+
+  const App = () => {
+    value = useEnv("ULTRA_MODE");
+    return (
+      <html>
+        <head>
+          <title>useContext</title>
+        </head>
+        <body>
+          <div>{value}</div>
+        </body>
+      </html>
+    );
+  };
+
+  const stream = await renderToStream(
+    <App />,
+    undefined,
+    {
+      baseUrl: "/",
+      importMap: { imports: {} },
+      assetManifest: new Map(),
+    },
+  );
+
+  const response = new Response(stream);
+  const text = await response.text();
+
+  assertEquals(
+    text.includes("foo"),
+    true,
+  );
+
+  assertEquals(
+    text.includes("globalThis.__ULTRA_ENV"),
+    true,
+  );
+});

--- a/test/unit/use-env.test.tsx
+++ b/test/unit/use-env.test.tsx
@@ -12,7 +12,7 @@ Deno.test("useEnv hook", async () => {
     return (
       <html>
         <head>
-          <title>useContext</title>
+          <title>useEnv</title>
         </head>
         <body>
           <div>{value}</div>


### PR DESCRIPTION
This PR changes the env available on the client to include `ULTRA_MODE`. Also fixes an annoying warning about unique "key" prop