### PR TITLE
fix: allow overriding browser entrypoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:jammy",
   "features": {
     "ghcr.io/devcontainers-contrib/features/deno:1": {
-      "version": "1.35.0"
+      "version": "1.36.4"
     }
   },
   "customizations": {

--- a/deno.json
+++ b/deno.json
@@ -10,18 +10,21 @@
   },
   "lock": false,
   "lint": {
-    "files": {
-      "exclude": [
-        ".deno-cache"
-      ]
-    }
+    "exclude": [
+      ".deno-cache"
+    ]
   },
   "fmt": {
-    "files": {
-      "exclude": [
-        ".deno-cache"
-      ]
-    },
+    "exclude": [
+      ".deno-cache",
+      "examples/**/.ultra",
+      "examples/**/importMap.dev.json",
+      "examples/**/deno.dev.json",
+      "examples/with-netlify-(WIP)/.netlify/*",
+      "examples/ultra-website/src/content/*",
+      "examples/with-mdx/src/content/*",
+      "test/fixture/output/*"
+    ],
     "options": {
       "indentWidth": 2,
       "useTabs": false,

--- a/examples/lite/app.tsx
+++ b/examples/lite/app.tsx
@@ -24,4 +24,4 @@ export default function App() {
   );
 }
 
-typeof (document) !== "undefined" && hydrate(document, <App />);
+typeof document !== "undefined" && hydrate(document, <App />);

--- a/test/fixture/client.foo.tsx
+++ b/test/fixture/client.foo.tsx
@@ -1,0 +1,6 @@
+import hydrate from "ultra/hydrate.js";
+
+hydrate(
+  document,
+  <div>Something else!</div>,
+);

--- a/test/fixture/server.test.ts
+++ b/test/fixture/server.test.ts
@@ -37,6 +37,19 @@ Deno.test(
       assertEquals(content.includes("<strong>Ultra</strong>"), true);
     });
 
+    await t.step("it can override the entrypoint", async () => {
+      const response = await server.request("http://localhost/foo");
+      const content = await response.text();
+
+      assertEquals(response.status, 200);
+      assertEquals(
+        response.headers.get("content-type"),
+        "text/html; charset=utf-8",
+      );
+
+      assertEquals(content.includes("client.foo.tsx"), true);
+    });
+
     await t.step("it can serve static assets from '/public'", async () => {
       const response = await server.request("https://localhost/style.css");
       response.body?.cancel();

--- a/test/fixture/server.tsx
+++ b/test/fixture/server.tsx
@@ -40,6 +40,12 @@ server.get("*", async (context) => {
   // clear query cache
   queryClient.clear();
 
+  const requestUrl = new URL(context.req.url);
+
+  const entrypoint = requestUrl.pathname === "/foo"
+    ? import.meta.resolve("./client.foo.tsx")
+    : import.meta.resolve("./client.tsx");
+
   /**
    * Render the request
    */
@@ -49,6 +55,9 @@ server.get("*", async (context) => {
         <App />
       </TWProvider>
     </TRPCServerProvider>,
+    {
+      entrypoint,
+    },
   );
 
   return context.body(result, 200, {


### PR DESCRIPTION
This PR adds the option to override the browser entrypoint when calling `server.render`