### PR TITLE
tech: narrow typings for refactor server handler

### DIFF
--- a/lib/react/renderer.ts
+++ b/lib/react/renderer.ts
@@ -1,10 +1,11 @@
+import { type ReactDOMServerReadableStream } from "react-dom/server";
 import { toFileUrl } from "../deps.ts";
 import { type RequestHandler } from "../handler.ts";
 import { type RendererOptions } from "../renderer.ts";
 import { createUltraUrlTransformStream } from "../stream.ts";
 
 export function createRenderHandler(
-  options: RendererOptions<JSX.Element>,
+  options: RendererOptions<ReactDOMServerReadableStream>,
 ): RequestHandler {
   const root = options.root instanceof URL
     ? options.root

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -1,11 +1,14 @@
-export interface RendererOptions<T> {
+// See:
+// https://react.dev/reference/react-dom/server/renderToReadableStream#usage
+// https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+export interface RendererOptions<T extends ReadableStream> {
   root: string | URL;
   render: RenderFunction<T>;
 }
 
 type RenderResult<T> = Promise<T> | T | Promise<Response> | Response;
 
-type RenderFunction<T> = (
+type RenderFunction<T extends ReadableStream> = (
   request: Request,
   params?: Map<string, string | undefined>,
 ) => RenderResult<T>;


### PR DESCRIPTION
I believe both of those renderers exist in the scope of the server.

On in the framework-agnostic land I believe you want to narrow the rendered type to `ReadableStream`.
This typing would work as a return type for React's SSR, but I think it will be better to use their fancy `ReactDOMServerReadableStream` type.

I think it is ready for merge, running app from `./app` works and I can click the button to increment the counter.