### PR TITLE
tech: revive example basic on refactor branch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
   "[css]": {
     "editor.defaultFormatter": "vscode.css-language-features"
   },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno",
+  },
   "deno.enablePaths": [
     "./examples/ultra-website",
     "./examples/basic",

--- a/examples/basic/server.tsx
+++ b/examples/basic/server.tsx
@@ -1,26 +1,51 @@
-import { createServer } from "ultra/server.ts";
+import { renderToReadableStream } from "react-dom/server";
+import { createCompilerHandler } from "ultra/lib/react/compiler.ts";
+import { createRenderHandler } from "ultra/lib/react/renderer.ts";
+import UltraServer from "ultra/lib/react/server.js";
 import App from "./src/app.tsx";
+import { readImportMap } from "ultra/lib/utils/import-map.ts";
+import { createStaticHandler } from "ultra/lib/static/handler.ts";
+import { composeHandlers } from "ultra/lib/handler.ts";
 
-const server = await createServer({
-  importMapPath: Deno.env.get("ULTRA_MODE") === "development"
-    ? import.meta.resolve("./importMap.dev.json")
-    : import.meta.resolve("./importMap.json"),
-  browserEntrypoint: import.meta.resolve("./client.tsx"),
+const root = Deno.cwd();
+
+const importMap = Deno.env.get("ULTRA_MODE") === "development"
+  ? await readImportMap("./importMap.dev.json")
+  : await readImportMap("./importMap.json");
+
+const renderer = createRenderHandler({
+  root,
+  render(request) {
+    return renderToReadableStream(
+      <UltraServer request={request} importMap={importMap}>
+        <App />
+      </UltraServer>,
+      {
+        bootstrapModules: [
+          import.meta.resolve("./client.tsx"),
+        ],
+      },
+    );
+  },
 });
 
-server.get("*", async (context) => {
-  /**
-   * Render the request
-   */
-  const result = await server.render(<App />);
-
-  return context.body(result, 200, {
-    "content-type": "text/html; charset=utf-8",
-  });
+const compiler = createCompilerHandler({
+  root,
 });
 
-if (import.meta.main) {
-  Deno.serve(server.fetch);
-}
+const staticHandler = createStaticHandler({
+  pathToRoot: import.meta.resolve("./public"),
+});
 
-export default server;
+const executeHandlers = composeHandlers(
+  compiler,
+  renderer,
+  staticHandler
+);
+
+Deno.serve((request) => {
+  const response = executeHandlers(request);
+  if (response) return response;
+
+  return new Response("Not Found", { status: 404 });
+});

--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -2,3 +2,23 @@ export interface RequestHandler {
   handleRequest: (request: Request) => Promise<Response>;
   supportsRequest: (request: Request) => boolean;
 }
+
+export function executeHandler (request: Request, handler: RequestHandler) {
+  try {
+    if (handler.supportsRequest(request)) {
+      return handler.handleRequest(request);
+    }
+  } catch (_) {
+    return null;
+  }
+}
+
+export function composeHandlers (...handlers: RequestHandler[]) {
+  return function executeHandlerArray (request: Request) {
+    for (const handler of handlers) {
+      const response = executeHandler(request, handler);
+      if (response) return response;
+    }
+    return null;
+  }
+}

--- a/lib/static/handler.ts
+++ b/lib/static/handler.ts
@@ -1,0 +1,49 @@
+import { join } from "https://deno.land/std@0.203.0/url/mod.ts";
+import { type RequestHandler } from "../handler.ts";
+
+type StaticHandlerOptions = {
+  pathToRoot: URL | string;
+  prefix?: string; 
+};
+
+export function createStaticHandler(
+  options: StaticHandlerOptions,
+): RequestHandler {
+  const {
+    pathToRoot,
+    prefix = "/"
+  } = options;
+
+  const root = new URL(pathToRoot.toString(), import.meta.url);
+
+  const handleRequest = async (request: Request): Promise<Response> => {
+    const { pathname } = new URL(request.url);
+    const filePath = pathname.replace(prefix, "./");
+    const fileUrl = join(root, filePath);
+
+    // See https://docs.deno.com/runtime/tutorials/file_server#example
+    let file;
+    try {
+      file = await Deno.open(fileUrl, { read: true });
+    } catch {
+      // If the file cannot be opened, return a "404 Not Found" response
+      throw "Can't handle this request";
+    }
+
+    // Build a readable stream so the file doesn't have to be fully loaded into
+    // memory while we send it
+    const readableStream = file.readable;
+
+    // Build and send the response
+    return new Response(readableStream);
+  };
+
+  const supportsRequest = (request: Request): boolean => {
+    return true; // use it as a fallback for now
+  };
+
+  return {
+    supportsRequest,
+    handleRequest,
+  };
+}

--- a/lib/utils/import-map.ts
+++ b/lib/utils/import-map.ts
@@ -1,4 +1,4 @@
-import { resolve, toFileUrl } from "../deps.ts";
+import { type ImportMapJson, resolve, toFileUrl } from "../deps.ts";
 import { Mode } from "../types.ts";
 
 export function resolveImportMapPath(mode: Mode, root: string, path: string) {
@@ -7,4 +7,10 @@ export function resolveImportMapPath(mode: Mode, root: string, path: string) {
   }
 
   return toFileUrl(resolve(root, "importMap.browser.json")).href;
+}
+
+export const readImportMap = async (path: string) => {
+  const importMap = await Deno.readTextFile(path);
+  // TODO: zod-check the import map
+  return JSON.parse(importMap) as ImportMapJson;
 }


### PR DESCRIPTION
I've repaired the `basic` example

Ive based on branch with refactor.

Added a utility to execute and compose handlers AND added an option for handler to throw to manifest that something went wrong in controlled way.

Created static file handler and I've tried my best to make it to stream data from reader.

I am not sure if this utility for reading import file will be useful - adding it for now.

Welcome back :eyes: 

![image](https://github.com/exhibitionist-digital/ultra/assets/8364951/59824bff-4f17-41d3-9b65-b9b78aa8e82e)
